### PR TITLE
Add BPM readout and genre guess

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This project contains utilities to drive DMX lights.
 ## Beat-controlled blinking
 
 The `beat_dmx.py` script listens to microphone input, detects beats using `aubio`,
-and blinks a chosen DMX channel every time a beat is found.
+and blinks a chosen DMX channel every time a beat is found. It also periodically
+prints the estimated BPM and a rough music genre classification.
 
 ### Usage
 

--- a/beat_dmx.py
+++ b/beat_dmx.py
@@ -15,6 +15,8 @@ class DmxBeatBlinker:
         self.wrapper = ClientWrapper()
         self.client = self.wrapper.Client()
         self.tempo = aubio.tempo("default", 1024, 512, samplerate)
+        self.beat_times = []
+        self.last_bpm_print = time.time()
 
     def _send_dmx_value(self, value: int):
         data = bytearray(512)
@@ -27,13 +29,45 @@ class DmxBeatBlinker:
         time.sleep(0.05)
         self._send_dmx_value(0)
 
+    def _compute_bpm(self) -> float:
+        """Return the average BPM from recorded beat times."""
+        if len(self.beat_times) < 2:
+            return 0.0
+        intervals = np.diff(self.beat_times)
+        if len(intervals) == 0:
+            return 0.0
+        return 60.0 / np.mean(intervals)
+
+    @staticmethod
+    def _detect_genre(bpm: float) -> str:
+        """Rough genre estimation based on BPM."""
+        if bpm > 140:
+            return "Metal"
+        if bpm > 110:
+            return "Rock"
+        if bpm > 90:
+            return "Pop"
+        return "Slow"
+
     def audio_callback(self, indata, frames, time_info, status):
         if status:
             print(status, flush=True)
         samples = np.frombuffer(indata, dtype=np.float32)
+        now = time.time()
         if self.tempo(samples):
             print(f"Beat @ {self.tempo.get_last_s():.2f}s", flush=True)
             self._blink()
+            self.beat_times.append(now)
+        if now - self.last_bpm_print >= 10:
+            bpm = self._compute_bpm()
+            if bpm:
+                print(f"Estimated BPM: {bpm:.2f}", flush=True)
+                genre = self._detect_genre(bpm)
+                print(f"Likely genre: {genre}", flush=True)
+            else:
+                print("Insufficient data for BPM", flush=True)
+            self.last_bpm_print = now
+            self.beat_times = [t for t in self.beat_times if now - t <= 60]
 
     def run(self):
         with sd.InputStream(channels=1, callback=self.audio_callback,


### PR DESCRIPTION
## Summary
- blink DMX lights on beats
- periodically compute BPM and guess music genre
- document new features

## Testing
- `python -m py_compile beat_dmx.py`

------
https://chatgpt.com/codex/tasks/task_e_686e9f24e2ac8329bf64dbffa9c861f6