### PR TITLE
Add beat detection script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DMX Show
 
-This project contains utilities to drive DMX lights.
+This project contains utilities to drive DMX lights and detect beats from microphone input.
 
 ## Beat-controlled blinking
 
@@ -18,3 +18,13 @@ python beat_dmx.py --universe 1 --channel 1
 Ensure you have PortAudio installed for microphone access and that an OLA
 daemon is running to handle the DMX output.
 
+## Standalone beat detection
+
+If you just want to detect beats without sending DMX commands, use `beat_detection.py`:
+
+```bash
+pip install -r requirements.txt
+python beat_detection.py
+```
+
+On Windows, you can run `install_requirements.ps1` to install the Python dependencies.

--- a/beat_detection.py
+++ b/beat_detection.py
@@ -1,0 +1,77 @@
+import argparse
+import time
+
+import numpy as np
+import sounddevice as sd
+import aubio
+
+
+class BeatDetector:
+    def __init__(self, samplerate: int = 44100):
+        self.samplerate = samplerate
+        self.tempo = aubio.tempo("default", 1024, 512, samplerate)
+        self.beat_times = []
+        self.last_bpm_print = time.time()
+
+    def _compute_bpm(self) -> float:
+        """Return the average BPM from recorded beat times."""
+        if len(self.beat_times) < 2:
+            return 0.0
+        intervals = np.diff(self.beat_times)
+        if len(intervals) == 0:
+            return 0.0
+        return 60.0 / np.mean(intervals)
+
+    @staticmethod
+    def _detect_genre(bpm: float) -> str:
+        """Rough genre estimation based on BPM."""
+        if bpm > 140:
+            return "Metal"
+        if bpm > 110:
+            return "Rock"
+        if bpm > 90:
+            return "Pop"
+        return "Slow"
+
+    def audio_callback(self, indata, frames, time_info, status):
+        if status:
+            print(status, flush=True)
+        samples = np.frombuffer(indata, dtype=np.float32)
+        now = time.time()
+        if self.tempo(samples):
+            print(f"Beat @ {self.tempo.get_last_s():.2f}s", flush=True)
+            self.beat_times.append(now)
+        if now - self.last_bpm_print >= 10:
+            bpm = self._compute_bpm()
+            if bpm:
+                print(f"Estimated BPM: {bpm:.2f}", flush=True)
+                genre = self._detect_genre(bpm)
+                print(f"Likely genre: {genre}", flush=True)
+            else:
+                print("Insufficient data for BPM", flush=True)
+            self.last_bpm_print = now
+            self.beat_times = [t for t in self.beat_times if now - t <= 60]
+
+    def run(self):
+        with sd.InputStream(channels=1, callback=self.audio_callback,
+                            samplerate=self.samplerate, blocksize=512):
+            print("Listening for beats. Press Ctrl+C to stop.")
+            try:
+                while True:
+                    sd.sleep(1000)
+            except KeyboardInterrupt:
+                print("Stopping")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Detect beats from microphone input")
+    parser.add_argument("--samplerate", type=int, default=44100,
+                        help="Audio samplerate")
+    args = parser.parse_args()
+
+    detector = BeatDetector(samplerate=args.samplerate)
+    detector.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/install_requirements.ps1
+++ b/install_requirements.ps1
@@ -1,0 +1,2 @@
+python -m pip install --upgrade pip
+pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ sounddevice
 aubio
 numpy
 scipy
-ola


### PR DESCRIPTION
## Summary
- implement `beat_detection.py` to print beat info without DMX output
- trim `requirements.txt` to detection-only packages
- document beat detection workflow in the README
- add `install_requirements.ps1` for Windows

## Testing
- `python -m py_compile beat_dmx.py beat_detection.py`


------
https://chatgpt.com/codex/tasks/task_e_686ea0f3a0a483299f8c9cee3dbd07cb