### PR TITLE
Improve genre detection heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This project contains utilities to drive DMX lights and detect beats from microp
 
 The `beat_dmx.py` script listens to microphone input, detects beats using `aubio`,
 and blinks a chosen DMX channel every time a beat is found. It also periodically
-prints the estimated BPM and a rough music genre classification.
+prints the estimated BPM and a rough music genre classification based on
+adjustable BPM ranges.
 
 ### Usage
 
@@ -38,7 +39,7 @@ command line flags:
 
 ```bash
 python beat_detection.py --amplitude-threshold 0.02 \
-    --start-duration 1.0 --end-duration 2.0
+    --start-duration 2.0 --end-duration 3.0
 ```
 
 On Windows, you can run `install_requirements.ps1` to install the Python dependencies.

--- a/beat_detection.py
+++ b/beat_detection.py
@@ -36,12 +36,14 @@ class BeatDetector:
     @staticmethod
     def _detect_genre(bpm: float) -> str:
         """Rough genre estimation based on BPM."""
-        if bpm > 140:
+        if bpm >= 160:
             return "Metal"
-        if bpm > 110:
+        if bpm >= 130:
             return "Rock"
-        if bpm > 90:
+        if bpm >= 100:
             return "Pop"
+        if bpm >= 80:
+            return "Jazz"
         return "Slow"
 
     def audio_callback(self, indata, frames, time_info, status):

--- a/beat_dmx.py
+++ b/beat_dmx.py
@@ -45,12 +45,14 @@ class DmxBeatBlinker:
     @staticmethod
     def _detect_genre(bpm: float) -> str:
         """Rough genre estimation based on BPM."""
-        if bpm > 140:
+        if bpm >= 160:
             return "Metal"
-        if bpm > 110:
+        if bpm >= 130:
             return "Rock"
-        if bpm > 90:
+        if bpm >= 100:
             return "Pop"
+        if bpm >= 80:
+            return "Jazz"
         return "Slow"
 
     def audio_callback(self, indata, frames, time_info, status):

--- a/parameters.py
+++ b/parameters.py
@@ -5,8 +5,8 @@ SAMPLERATE = 44100
 
 # Volume-based song state detection
 AMPLITUDE_THRESHOLD = 0.02  # RMS amplitude considered "loud"
-START_DURATION = 1.0        # seconds of sustained volume to mark song start
-END_DURATION = 2.0          # seconds of quiet to mark song end
+START_DURATION = 2.0        # seconds of sustained volume to mark song start
+END_DURATION = 3.0          # seconds of quiet to mark song end
 
 # DMX blink script defaults
 UNIVERSE = 1


### PR DESCRIPTION
## Summary
- refine BPM thresholds for genre detection
- expand default song state durations
- document threshold changes in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python beat_detection.py --help | head` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eadf2dd708329bf213c7d3d87dda0