### PR TITLE
Enhance beat detection output

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ python beat_detection.py
 ```
 
 Output is limited to a short summary printed every 10 seconds to avoid
-performance issues when detecting rapid beats.
+performance issues when detecting rapid beats. Each summary also prints the
+current stage lighting state and whether smoke bursts are firing. LumiPar 12UAW5
+units double as house lights, overhead effects pulse with BPM and smoke bursts
+last 3 seconds with a 30-second gap.
 
 The detector will also analyze the incoming volume (VU level) to determine when a
 song is starting, ongoing, ending or if there is an intermission. Thresholds and

--- a/beat_detection.py
+++ b/beat_detection.py
@@ -13,7 +13,9 @@ class BeatDetector:
                  amplitude_threshold: float = parameters.AMPLITUDE_THRESHOLD,
                  start_duration: float = parameters.START_DURATION,
                  end_duration: float = parameters.END_DURATION,
-                 print_interval: float = parameters.PRINT_INTERVAL):
+                 print_interval: float = parameters.PRINT_INTERVAL,
+                 smoke_gap: float = parameters.SMOKE_GAP,
+                 smoke_duration: float = parameters.SMOKE_DURATION):
         self.samplerate = samplerate
         self.tempo = aubio.tempo("default", 1024, 512, samplerate)
         self.beat_times = []
@@ -22,9 +24,20 @@ class BeatDetector:
         self.start_duration = start_duration
         self.end_duration = end_duration
         self.print_interval = print_interval
+        self.smoke_gap = smoke_gap
+        self.smoke_duration = smoke_duration
+        self.last_smoke_time = 0.0
+        self.smoke_on = False
+        self.smoke_start_time = 0.0
         self.state = "Intermission"
         self.state_change_time = time.time()
         self.last_loud_time = 0.0
+        self.lighting_state = {
+            "moving_light": "Artist",
+            "stage_light": "Off",
+            "overhead_effects": "Off",
+            "karaoke_lights": "Off",
+        }
 
     def _compute_bpm(self) -> float:
         """Return the estimated BPM using recent beat intervals."""
@@ -50,6 +63,29 @@ class BeatDetector:
         if bpm >= 80:
             return "Jazz"
         return "Slow"
+
+    @staticmethod
+    def _genre_color(genre: str) -> str:
+        mapping = {
+            "Slow": "blue",
+            "Jazz": "amber",
+            "Pop": "pink",
+            "Rock": "red",
+            "Metal": "white",
+        }
+        return mapping.get(genre, "white")
+
+    def _print_state_change(self, **changes) -> None:
+        if changes:
+            print("Change:", flush=True)
+            for name, val in changes.items():
+                label = name.replace('_', ' ').title()
+                print(f"- {label}: {val}", flush=True)
+                self.lighting_state[name] = val
+        print("Current:", flush=True)
+        for name, val in self.lighting_state.items():
+            label = name.replace('_', ' ').title()
+            print(f"- {label}: {val}", flush=True)
 
     def audio_callback(self, indata, frames, time_info, status):
         if status:
@@ -77,7 +113,8 @@ class BeatDetector:
             elif not is_loud and now - self.last_loud_time > self.end_duration:
                 self.state = "Intermission"
                 print("Intermission", flush=True)
-        elif self.state == "Ongoing" and not is_loud and now - self.last_loud_time > self.end_duration:
+        elif (self.state == "Ongoing" and not is_loud and
+              now - self.last_loud_time > self.end_duration):
             self.state = "Ending"
             self.state_change_time = now
             print("Song ending", flush=True)
@@ -91,14 +128,31 @@ class BeatDetector:
                 print("Intermission", flush=True)
         if self.tempo(samples):
             self.beat_times.append(now)
+        # handle smoke timing
+        if self.smoke_on and now - self.smoke_start_time >= self.smoke_duration:
+            print("Smoke end", flush=True)
+            self.smoke_on = False
         if now - self.last_print >= self.print_interval:
             bpm = self._compute_bpm()
             if bpm:
                 print(f"Estimated BPM: {bpm:.2f}", flush=True)
                 genre = self._detect_genre(bpm)
                 print(f"Likely genre: {genre}", flush=True)
+                color = self._genre_color(genre)
+                self._print_state_change(
+                    moving_light="Artist",
+                    stage_light=color,
+                    overhead_effects=f"{color.capitalize()} (80%) Pulsing",
+                    karaoke_lights=f"{color.capitalize()} (10%)",
+                )
+                if not self.smoke_on and now - self.last_smoke_time >= self.smoke_gap:
+                    print("Smoke start", flush=True)
+                    self.smoke_on = True
+                    self.smoke_start_time = now
+                    self.last_smoke_time = now
             else:
                 print("Insufficient data for BPM", flush=True)
+                self._print_state_change(moving_light="Audience", stage_light="Off")
             self.last_print = now
             self.beat_times = [t for t in self.beat_times if now - t <= 60]
 
@@ -130,13 +184,21 @@ def main() -> None:
     parser.add_argument("--print-interval", type=float,
                         default=parameters.PRINT_INTERVAL,
                         help="Seconds between BPM summaries")
+    parser.add_argument("--smoke-gap", type=float,
+                        default=parameters.SMOKE_GAP,
+                        help="Seconds between automatic smoke bursts")
+    parser.add_argument("--smoke-duration", type=float,
+                        default=parameters.SMOKE_DURATION,
+                        help="Length of each smoke burst in seconds")
     args = parser.parse_args()
 
     detector = BeatDetector(samplerate=args.samplerate,
                             amplitude_threshold=args.amplitude_threshold,
                             start_duration=args.start_duration,
                             end_duration=args.end_duration,
-                            print_interval=args.print_interval)
+                            print_interval=args.print_interval,
+                            smoke_gap=args.smoke_gap,
+                            smoke_duration=args.smoke_duration)
     detector.run()
 
 


### PR DESCRIPTION
## Summary
- expand BeatDetector to track lighting state and smoke timing
- show stage lighting and smoke info every print interval
- document beat detection output in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ebd24755883298df36753d1654724