### PR TITLE
Add DMX serial interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sounddevice
 aubio
 numpy
 scipy
+pyserial

--- a/src/Prolights_LumiPar7UTRI_8ch.py
+++ b/src/Prolights_LumiPar7UTRI_8ch.py
@@ -1,0 +1,35 @@
+"""Helpers for the Prolights LumiPar 7 UTRI fixture in 8-channel mode."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Dict
+
+# Channel offsets (0-indexed) according to the fixture manual
+RED_OFFSET = 0
+GREEN_OFFSET = 1
+BLUE_OFFSET = 2
+DIMMER_OFFSET = 6
+
+
+def blink_red(send_func: Callable[[Dict[int, int]], None], *, start_address: int = 1,
+              blink_times: int = 3, interval: float = 0.1) -> None:
+    """Blink the fixture red using ``send_func`` to transmit DMX values.
+
+    ``send_func`` should accept a mapping of DMX channel numbers to values.
+    Only the channels relevant for this fixture are included in the map.
+    """
+    on_frame = {
+        start_address + RED_OFFSET: 255,
+        start_address + GREEN_OFFSET: 0,
+        start_address + BLUE_OFFSET: 0,
+        start_address + DIMMER_OFFSET: 255,
+    }
+    off_frame = {
+        start_address + DIMMER_OFFSET: 0,
+    }
+    for _ in range(blink_times):
+        send_func(on_frame)
+        time.sleep(interval)
+        send_func(off_frame)
+        time.sleep(interval)

--- a/src/dmx.py
+++ b/src/dmx.py
@@ -1,0 +1,49 @@
+"""Simple DMX sender for an FTDI USB to DMX cable on COM4."""
+
+from __future__ import annotations
+
+import time
+from typing import Mapping
+
+import serial
+
+
+class DmxSerial:
+    """Send DMX frames over a serial connection."""
+
+    def __init__(self, port: str = "COM4", channels: int = 512) -> None:
+        self.serial = serial.Serial(
+            port=port,
+            baudrate=250000,
+            bytesize=serial.EIGHTBITS,
+            parity=serial.PARITY_NONE,
+            stopbits=serial.STOPBITS_TWO,
+        )
+        self.channels = channels
+        # Allocate frame including the start code at index 0
+        self.frame = bytearray(channels + 1)
+        self.frame[0] = 0
+
+    def send(self, values: Mapping[int, int]) -> None:
+        """Update DMX channels and transmit the frame."""
+        for channel, value in values.items():
+            if not 1 <= channel <= self.channels:
+                raise ValueError(f"Channel {channel} out of range")
+            self.frame[channel] = max(0, min(255, value))
+
+        # Transmit DMX break and frame
+        self.serial.break_condition = True
+        time.sleep(0.0001)
+        self.serial.break_condition = False
+        time.sleep(0.000012)
+        self.serial.write(self.frame)
+        self.serial.flush()
+
+    def close(self) -> None:
+        self.serial.close()
+
+    def __enter__(self) -> "DmxSerial":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()

--- a/tests/test_lumipar7utri.py
+++ b/tests/test_lumipar7utri.py
@@ -1,0 +1,14 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from Prolights_LumiPar7UTRI_8ch import blink_red
+
+def test_blink_red_sends_correct_frames(monkeypatch):
+    calls = []
+    def fake_send(data):
+        # store a copy to avoid mutation
+        calls.append(dict(data))
+
+    monkeypatch.setattr('time.sleep', lambda *_: None)
+    blink_red(fake_send, start_address=10, blink_times=2, interval=0.01)
+    on_frame = {10: 255, 11: 0, 12: 0, 16: 255}
+    off_frame = {16: 0}
+    assert calls == [on_frame, off_frame, on_frame, off_frame]


### PR DESCRIPTION
## Summary
- create `dmx.py` with a simple serial sender for an FTDI USB/DMX adapter
- add `pyserial` dependency for DMX output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fdff290dc8329a77af77ee5245e8c