### PR TITLE
Add LumiPar 7UTRI blink example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Default values for the DMX universe, channel, audio samplerate and song
 detection thresholds are defined in `parameters.py`. You can edit that file or
 override them with command-line options.
 
+## Quick LumiPar 7UTRI blink
+
+Run `blink_red.py` to flash a LumiPar 7UTRI fixture without beat detection:
+
+```bash
+python blink_red.py --port /dev/ttyUSB0 --start-address 1 --blink-times 3
+```
+
+
 ## Stage lighting and smoke demo
 
 `beat_dmx.py` can also trigger smoke bursts and print the current stage light

--- a/blink_red.py
+++ b/blink_red.py
@@ -1,0 +1,25 @@
+import argparse
+
+from dmx import DmxSerial
+from Prolights_LumiPar7UTRI_8ch import blink_red
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Blink LumiPar 7UTRI red")
+    parser.add_argument("--port", default="COM4",
+                        help="Serial port, e.g. COM4 or /dev/ttyUSB0")
+    parser.add_argument("--start-address", type=int, default=1,
+                        help="Fixture start address")
+    parser.add_argument("--blink-times", type=int, default=5,
+                        help="Number of blinks")
+    parser.add_argument("--interval", type=float, default=0.2,
+                        help="Seconds between frames")
+    args = parser.parse_args()
+
+    with DmxSerial(port=args.port) as dmx:
+        blink_red(dmx.send, start_address=args.start_address,
+                  blink_times=args.blink_times, interval=args.interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small script to blink a LumiPar 7UTRI fixture
- document the new script in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fe7f5e0408329a418011287fb3dfc