### PR TITLE
Add continuous DMX frame thread

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,8 +1,9 @@
 # dmx.py
 
 - Base class for DMX devices.
-- Communication class for sending DMX signals. `DMX` takes device classes and start
-  addresses as parameters.
+ - Communication class for sending DMX signals. `DMX` now runs a background
+   thread that repeats the last frame until new data is computed. Device classes
+   and start addresses are passed to the constructor.
 
 # Prolights_LumiPar7UTRI_8ch.py
 

--- a/tests/test_dmx_thread.py
+++ b/tests/test_dmx_thread.py
@@ -1,0 +1,45 @@
+import sys
+import pathlib
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from dmx import DMX, DmxDevice
+
+
+class DummyDevice(DmxDevice):
+    def __init__(self, addr: int) -> None:
+        super().__init__({"val": addr})
+
+
+def test_dmx_thread_repeats_and_updates(monkeypatch):
+    calls = []
+
+    class FakeSerial:
+        def __init__(self, *_, **__):
+            pass
+
+        def send(self, frame):
+            calls.append(dict(frame))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr('dmx.DmxSerial', FakeSerial)
+    dmx = DMX([(DummyDevice, 1)], fps=100)
+    dmx.update()
+    dmx.start()
+    time.sleep(0.05)
+    # after some time multiple frames should have been sent
+    first_len = len(calls)
+    assert first_len >= 3
+    assert all(c == {1: 0} for c in calls)
+
+    dmx.devices[0].set_channel('val', 10)
+    dmx.update()
+    time.sleep(0.05)
+    dmx.stop()
+    assert calls[-1] == {1: 10}


### PR DESCRIPTION
## Summary
- send DMX frames on a background thread
- update documentation for new behaviour
- test repeating and updating frames

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ff9deade483299cc1c2dcdbee44e6