### PR TITLE
Implement missing LumiPar 7UTRI channels

### DIFF
--- a/src/Prolights_LumiPar7UTRI_8ch.py
+++ b/src/Prolights_LumiPar7UTRI_8ch.py
@@ -9,7 +9,11 @@ class Prolights_LumiPar7UTRI_8ch(DmxDevice):
         "red": 0,
         "green": 1,
         "blue": 2,
+        "color_macros": 3,
+        "strobe": 4,
+        "programs": 5,
         "dimmer": 6,
+        "dimmer_speed": 7,
     }
 
     def __init__(self, start_address: int) -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,23 @@ from dmx import DMX
 from Prolights_LumiPar7UTRI_8ch import Prolights_LumiPar7UTRI_8ch
 
 
+def blink_red(send: Callable[[Dict[int, int]], None], *, start_address: int = 1,
+              blink_times: int = 5, interval: float = 0.2) -> None:
+    """Blink fixture red a number of times."""
+    on_frame = {
+        start_address: 255,
+        start_address + 1: 0,
+        start_address + 2: 0,
+        start_address + 6: 255,
+    }
+    off_frame = {start_address + 6: 0}
+    for _ in range(blink_times):
+        send(on_frame)
+        time.sleep(interval)
+        send(off_frame)
+        time.sleep(interval)
+
+
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add all 8 channels for `Prolights_LumiPar7UTRI_8ch`
- restore `blink_red` helper in `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fff84853c8329be9810114b8963bd