### PR TITLE
Fix smoke machine initialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -174,7 +174,8 @@ class BeatDMXShow:
         ):
             self.controller = ctrl
             self.groups = ctrl.groups
-            self.smoke = ctrl.groups.get("Smoke Machine", ctrl.devices[8])
+            smoke_group = ctrl.groups.get("Smoke Machine")
+            self.smoke = smoke_group[0] if smoke_group else ctrl.devices[8]
             self._print_state_change(self.scenario.updates)
             print("Listening for beats. Press Ctrl+C to stop.")
             try:


### PR DESCRIPTION
## Summary
- set the smoke machine to the first device in the `Smoke Machine` group

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870f4a1b6348329b5169d18bc71dea0