### PR TITLE
Modify Overhead Effects control

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,12 @@ Stage lights fade to black as overheads rise to 30% warm white. Moving head cent
 - 3-s smoke burst every 30 s.
 
 ### Song Ongoing - Rock (130-160 BPM)
-- Overhead red pulse each beat with 1-s white strobe every 8 beats.
+- Overhead red pulse each beat using beat detection.
 - Moving head fast pan and tilt.
 - 3-s smoke burst every 30 s.
 
 ### Song Ongoing - Metal (>160 BPM)
-- Overhead white strobe each beat.
+- Overhead bright white pulse each beat.
 - Moving head erratic sweeps.
 - 3-s smoke burst every 30 s.
 

--- a/parameters.py
+++ b/parameters.py
@@ -88,7 +88,7 @@ class Scenario(Enum):
         {
             "House Lights": {"warm_white": 51, "dimmer": 51},
             "Moving Head": {"dimmer": 0},
-            "Overhead Effects": {"dimmer": 0, "strobe": 0},
+            "Overhead Effects": {"dimmer": 0},
             "Karaoke Lights": {"dimmer": 0},
             "Smoke Machine": {"smoke_gap": 60000, "duration": 5000},
         },
@@ -108,7 +108,7 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"pan": 32768, "tilt": 49152, "dimmer": 255},
-            "Overhead Effects": {"white": 77, "dimmer": 77, "strobe": 0},
+            "Overhead Effects": {"white": 77, "dimmer": 77},
             "Karaoke Lights": {"dimmer": 0},
             "Smoke Machine": {"smoke_gap": 30000, "duration": 3000},
         },
@@ -134,7 +134,7 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "dimmer": 255, "strobe": 0},
+            "Overhead Effects": {"red": 255, "dimmer": 255},
             "Karaoke Lights": {"red": 26, "dimmer": 26},
             "Smoke Machine": {"smoke_gap": 15000, "duration": 2000},
         },
@@ -163,7 +163,7 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "green": 96, "dimmer": 255, "strobe": 0},
+            "Overhead Effects": {"red": 255, "green": 96, "dimmer": 255},
             "Karaoke Lights": {"red": 26, "green": 10, "dimmer": 26},
             "Smoke Machine": {"smoke_gap": 30000, "duration": 3000},
         },
@@ -197,7 +197,7 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "blue": 96, "dimmer": 255, "strobe": 0},
+            "Overhead Effects": {"red": 255, "blue": 96, "dimmer": 255},
             "Karaoke Lights": {"red": 26, "blue": 10, "dimmer": 26},
             "Smoke Machine": {"smoke_gap": 30000, "duration": 3000},
         },
@@ -231,14 +231,13 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "strobe": 255, "dimmer": 255},
+            "Overhead Effects": {"red": 255, "dimmer": 255},
             "Karaoke Lights": {"red": 26, "dimmer": 26},
             "Smoke Machine": {"smoke_gap": 30000, "duration": 3000},
         },
         {
             "Overhead Effects": {
                 "red": 255,
-                "strobe": 255,
                 "dimmer": 255,
                 "duration": 100,
             },
@@ -265,14 +264,13 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"white": 255, "strobe": 255, "dimmer": 255},
+            "Overhead Effects": {"white": 255, "dimmer": 255},
             "Karaoke Lights": {"white": 26, "dimmer": 26},
             "Smoke Machine": {"smoke_gap": 30000, "duration": 3000},
         },
         {
             "Overhead Effects": {
                 "white": 255,
-                "strobe": 255,
                 "dimmer": 255,
                 "duration": 100,
             },
@@ -293,7 +291,7 @@ class Scenario(Enum):
         {
             "House Lights": {"warm_white": 128, "dimmer": 128},
             "Moving Head": {"pan": 32768, "tilt": 16384, "dimmer": 255},
-            "Overhead Effects": {"dimmer": 0, "strobe": 0},
+            "Overhead Effects": {"dimmer": 0},
             "Karaoke Lights": {"dimmer": 0},
             "Smoke Machine": {"smoke_gap": 30000, "duration": 3000},
         },


### PR DESCRIPTION
## Summary
- remove all strobe usage from lighting scenarios
- expose audio level from beat detection
- adjust Overhead Effects dimmer using VU level in the main show
- document rock/metal cues without strobe

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68710d74ee4083299ee386c5d22e269b