### PR TITLE
Fix overhead dimmer scaling

### DIFF
--- a/main.py
+++ b/main.py
@@ -281,7 +281,8 @@ class BeatDMXShow:
         self._tick(now)
 
         # Update overhead dimmer based on VU level every callback
-        level = int(min(1.0, vu * 50.0) * 255)
+        # Scale VU level so overhead dimmer varies smoothly up to full
+        level = int(min(1.0, vu * 20.0) * 255)
         if level != self.last_vu_dimmer:
             self._apply_update("Overhead Effects", {"dimmer": level})
             self.last_vu_dimmer = level


### PR DESCRIPTION
## Summary
- adjust scaling for VU driven dimmer so it doesn't stay maxed out

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871164a21e48329a45bfb6b17af110e