### PR TITLE
Show min/max VU on dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ to ``BeatTrigger.on_beat`` to trigger other effects.
 Set ``SHOW_DASHBOARD`` in ``parameters.py`` to ``True`` to display a static
 console dashboard instead of log lines. Only changed DMX values, BPM and smoke
 state refresh on screen so the current lighting status is always visible. The
-dashboard also prints the current VU level.
+dashboard also shows the current VU level along with minimum and maximum
+readings.
 
 ## Standalone beat detection
 

--- a/main.py
+++ b/main.py
@@ -38,6 +38,8 @@ class Dashboard:
         self.song_state = ""
         self.bpm = 0.0
         self.vu = 0.0
+        self.min_vu = float('inf')
+        self.max_vu = 0.0
         self.smoke = False
         self.status = ""
         self.groups: Dict[str, Dict[str, int]] = {}
@@ -57,6 +59,10 @@ class Dashboard:
 
     def set_vu(self, vu: float) -> None:
         self.vu = vu
+        if vu < self.min_vu:
+            self.min_vu = vu
+        if vu > self.max_vu:
+            self.max_vu = vu
         self._render()
 
     def set_smoke(self, on: bool) -> None:
@@ -76,7 +82,7 @@ class Dashboard:
             f"Scenario: {self.scenario}",
             f"Song state: {self.song_state}",
             f"BPM: {self.bpm:.2f}",
-            f"VU: {self.vu:.3f}",
+            f"VU: {self.vu:.3f} (Min: {self.min_vu:.3f} Max: {self.max_vu:.3f})",
             f"Smoke: {'On' if self.smoke else 'Off'}",
             f"Status: {self.status}",
             "",


### PR DESCRIPTION
## Summary
- track minimum and maximum VU values
- display current, min and max values on the dashboard
- document VU tracking in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711c6bcf888329a1ecc6a85d30bb63