### PR TITLE
Fix DMX color reset

### DIFF
--- a/main.py
+++ b/main.py
@@ -138,9 +138,10 @@ class BeatDMXShow:
                     fx.set_pan_tilt(pan or 0, tilt or 0)
                 except KeyError:
                     pass
-            for ch, val in values.items():
+            for ch in fx.channels:
                 if ch in {"pan", "tilt"}:
                     continue
+                val = values.get(ch, 0)
                 try:
                     fx.set_channel(ch, val)
                 except KeyError:


### PR DESCRIPTION
## Summary
- ensure `_apply_update` sets all fixture channels

## Testing
- `pytest -q`
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6871204230fc8329b6686e7e10aa6f22