### PR TITLE
Improve VU dimmer update

### DIFF
--- a/parameters.py
+++ b/parameters.py
@@ -29,8 +29,8 @@ CHANNEL = 1
 # How often to print BPM and genre summaries, in seconds
 PRINT_INTERVAL = 10
 
-# Scale factor for VU-based intensity updates
-VU_SCALING = 25.0
+# RMS level that results in full intensity for overhead effects
+VU_FULL = 0.3
 
 # Display a static dashboard instead of logging lines
 SHOW_DASHBOARD = True


### PR DESCRIPTION
## Summary
- poll VU levels when sending DMX frames instead of each audio callback
- add `VU_FULL` constant for mapping VU 0.3 -> 255 intensity
- support optional `pre_send` callback in `DMX`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68712383484c8329a9be54c8a4310fe2