### PR TITLE
Fix overhead dimmer update callback

### DIFF
--- a/main.py
+++ b/main.py
@@ -256,7 +256,7 @@ class BeatDMXShow:
             self.controller.update()
             self.smoke_on = False
 
-    def _update_overhead_from_vu(self) -> None:
+    def _update_overhead_from_vu(self, _ctrl: DMX) -> None:
         """Set Overhead Effects dimmer based on the latest VU reading."""
         level = int(min(1.0, self.current_vu / parameters.VU_FULL) * 255)
         if level != self.last_vu_dimmer:


### PR DESCRIPTION
## Summary
- accept DMX instance in `_update_overhead_from_vu`
- ensures overhead effects dimmer adjusts with VU level

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712840c0248329a8cfd58aa6f81f3b