### PR TITLE
Enable genre display on dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ console dashboard instead of log lines. Only changed DMX values, BPM and smoke
 state refresh on screen so the current lighting status is always visible. The
 dashboard also shows the current VU level along with minimum and maximum
 readings.
+Current song state and detected genre are displayed at the top.
+Running the show writes VU and dimmer levels to ``vu_dimmer.log`` for debugging.
 
 ## Standalone beat detection
 


### PR DESCRIPTION
## Summary
- show detected song genre on the dashboard
- rename dashboard fields from "Scenario" and "Song state" to "Genre" and "State"
- document the genre display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68712a45bed08329be63d2690490bbbc