### PR TITLE
Fix flicker when updating dimmer only

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,10 +139,9 @@ class BeatDMXShow:
                     fx.set_pan_tilt(pan or 0, tilt or 0)
                 except KeyError:
                     pass
-            for ch in fx.channels:
+            for ch, val in values.items():
                 if ch in {"pan", "tilt"}:
                     continue
-                val = values.get(ch, 0)
                 try:
                     fx.set_channel(ch, val)
                 except KeyError:


### PR DESCRIPTION
## Summary
- avoid resetting unspecified channels when updating fixtures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712daefd3c8329b7c8c77a5747454d