### PR TITLE
Add HPSS detections to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ This project contains utilities to drive DMX lights and detect beats from microp
 The `beat_dmx.py` script listens to microphone input, detects beats using `aubio`,
 and blinks a chosen DMX channel every time a beat is found. It periodically
 prints a summary of the estimated BPM and a rough music genre classification
-every 10 seconds based on
-adjustable BPM ranges. BPM is derived from the median of the most recent beat
-intervals, which helps smooth out any occasional mis-detected beats.
+every 10 seconds based on adjustable BPM ranges. BPM is derived from the median
+of the most recent beat intervals, which helps smooth out occasional
+mis-detected beats. The detector also provides lightweight heuristics for chorus
+and drum solo detection using spectral features.
 
 ### Usage
 
@@ -56,8 +57,8 @@ Set ``SHOW_DASHBOARD`` in ``parameters.py`` to ``True`` to display a static
 console dashboard instead of log lines. Only changed DMX values, BPM and smoke
 state refresh on screen so the current lighting status is always visible. The
 dashboard also shows the current VU level along with minimum and maximum
-readings.
-Current song state and detected genre are displayed at the top.
+readings. Chorus, drum solo and crescendo flags appear alongside the song
+state and detected genre at the top.
 Running the show writes VU and dimmer levels to ``vu_dimmer.log`` for debugging.
 
 ## Standalone beat detection
@@ -86,6 +87,15 @@ python beat_detection.py --amplitude-threshold 0.02 \
 ```
 
 On Windows, you can run `install_requirements.ps1` to install the Python dependencies.
+Librosa is installed automatically for spectral analysis.
+
+### Additional detection features
+
+`beat_detection.py` also exposes simple detection of drum solos, crescendo events
+and chorus sections. These rely on RMS loudness trends, harmonic/percussive
+ratios and spectral flatness. Results are heuristic and may produce occasional
+false triggers but can be useful for debugging lighting ideas. Their status is
+visible in dashboard mode.
 
 ## Devices
 

--- a/install_requirements.ps1
+++ b/install_requirements.ps1
@@ -1,2 +1,4 @@
 python -m pip install --upgrade pip
 pip install -r requirements.txt
+pip install librosa
+pip install aubio

--- a/main.py
+++ b/main.py
@@ -33,6 +33,11 @@ class Dashboard:
         self.max_vu = 0.0
         self.smoke = False
         self.status = ""
+        self.chorus = False
+        self.drum_solo = False
+        self.crescendo = False
+        self.snare = False
+        self.kick = False
         self.groups: Dict[str, Dict[str, int]] = {}
         self._last_out = ""
 
@@ -68,6 +73,26 @@ class Dashboard:
         self.status = status
         self._render()
 
+    def set_chorus(self, value: bool) -> None:
+        self.chorus = value
+        self._render()
+
+    def set_drum_solo(self, value: bool) -> None:
+        self.drum_solo = value
+        self._render()
+
+    def set_crescendo(self, value: bool) -> None:
+        self.crescendo = value
+        self._render()
+
+    def set_snare(self, value: bool) -> None:
+        self.snare = value
+        self._render()
+
+    def set_kick(self, value: bool) -> None:
+        self.kick = value
+        self._render()
+
     def _render(self) -> None:
         lines = [
             f"Genre: {self.genre}",
@@ -75,6 +100,11 @@ class Dashboard:
             f"BPM: {self.bpm:.2f}",
             f"VU: {self.vu:.3f} (Min: {self.min_vu:.3f} Max: {self.max_vu:.3f})",
             f"Smoke: {'On' if self.smoke else 'Off'}",
+            f"Chorus: {'Yes' if self.chorus else 'No'}",
+            f"Drum Solo: {'Yes' if self.drum_solo else 'No'}",
+            f"Crescendo: {'Yes' if self.crescendo else 'No'}",
+            f"Snare: {'Hit' if self.snare else 'No'}",
+            f"Kick: {'Hit' if self.kick else 'No'}",
             f"Status: {self.status}",
             "",
             "Groups:",
@@ -286,6 +316,13 @@ class BeatDMXShow:
         now = time.time()
 
         beat, bpm, state_changed, vu = self.detector.process(samples, now)
+
+        if self.dashboard_enabled:
+            self.dashboard.set_chorus(self.detector.is_chorus)
+            self.dashboard.set_drum_solo(self.detector.is_drum_solo)
+            self.dashboard.set_crescendo(self.detector.is_crescendo)
+            self.dashboard.set_snare(self.detector.snare_hit)
+            self.dashboard.set_kick(self.detector.kick_hit)
 
         for group, end in list(self.beat_ends.items()):
             if now >= end:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ aubio
 numpy
 scipy
 pyserial
+librosa


### PR DESCRIPTION
## Summary
- extend dashboard with chorus, drum solo, crescendo and hit status
- pipe BeatDetector flags to the dashboard
- document new dashboard output
- install aubio in Windows script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68714202f53483299e2f362998d95722