### PR TITLE
Add DMX_FPS setting to slow serial loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ daemon is running to handle the DMX output.
 Default values for the DMX universe, channel, audio samplerate and song
 detection thresholds are defined in `parameters.py`. You can edit that file or
 override them with command-line options.
+`DMX_FPS` in that file sets how many frames are sent each second.
 
 ## Quick LumiPar 7UTRI blink
 

--- a/main.py
+++ b/main.py
@@ -354,6 +354,7 @@ class BeatDMXShow:
             DMX(
                 devices,
                 port=parameters.COM_PORT,
+                fps=parameters.DMX_FPS,
                 pre_send=self._update_overhead_from_vu,
             ) as ctrl, sd.InputStream(
                 channels=1,

--- a/parameters.py
+++ b/parameters.py
@@ -38,6 +38,9 @@ SHOW_DASHBOARD = True
 # DMX hardware port
 COM_PORT = "COM4"
 
+# How many DMX frames to send per second
+DMX_FPS = 30
+
 # List of (fixture class, start_address, name) tuples describing the rig
 DEVICES = [
     #(Prolights_LumiPar12UAW5_7ch, 1, "House Lights"),


### PR DESCRIPTION
## Summary
- add `DMX_FPS` parameter for controlling send rate
- use `DMX_FPS` when creating the DMX controller
- document the new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68715097e1248329b7d16d132853f5ce