### PR TITLE
Add snare flash effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Stage lights fade to black as overheads rise to 30% warm white. Moving head cent
 
 * Overhead **candy pink** chase each beat (RGB: 255, 64, 200).
 * Accent color: **bright cyan** flashes synchronized with detected snare hits (high-frequency spectral peaks) (RGB: 0, 200, 255).
+* Snare hits push Overhead Effects to full intensity for 100 ms.
 * Moving head executes wide, energetic sweeps.
 * **3-second smoke burst** every **30 seconds**.
 

--- a/main.py
+++ b/main.py
@@ -324,6 +324,18 @@ class BeatDMXShow:
             self.dashboard.set_snare(self.detector.snare_hit)
             self.dashboard.set_kick(self.detector.kick_hit)
 
+        if self.detector.snare_hit:
+            update = {"dimmer": 255}
+            self._flush_beat_line()
+            if self.dashboard_enabled:
+                self.dashboard.set_group("Overhead Effects", update)
+            else:
+                print(f"Snare flash: {update}", flush=True)
+            self._apply_update("Overhead Effects", update)
+            self.beat_ends["Overhead Effects"] = max(
+                self.beat_ends.get("Overhead Effects", 0.0), now + 0.1
+            )
+
         for group, end in list(self.beat_ends.items()):
             if now >= end:
                 base = self.scenario.updates.get(group, {})


### PR DESCRIPTION
## Summary
- flash Overhead Effects to full intensity on snare hits
- mention the snare flash in the Pop show cues

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687153cc968c8329b244908b7c2e0da0