### PR TITLE
Handle audio overflows in dashboard

### DIFF
--- a/main.py
+++ b/main.py
@@ -360,7 +360,11 @@ class BeatDMXShow:
     def audio_callback(self, indata, frames, time_info, status) -> None:
         if status:
             self._flush_beat_line()
-            print(status, flush=True)
+            msg = str(status).strip()
+            if self.dashboard_enabled:
+                self.dashboard.set_status(msg)
+            else:
+                print(msg, flush=True)
         samples = np.frombuffer(indata, dtype=np.float32)
         now = time.time()
 


### PR DESCRIPTION
## Summary
- show sounddevice errors on dashboard instead of printing repeated lines

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871594e5e4c8329af79c2f192266e1b