### PR TITLE
Fix Overhead VU with snare

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Stage lights fade to black as overheads rise to 30% warm white. Moving head cent
 
 * Overhead **candy pink** chase each beat (RGB: 255, 64, 200).
 * Accent color: **bright cyan** flashes synchronized with detected snare hits (high-frequency spectral peaks) (RGB: 0, 200, 255).
-* Snare hits push Overhead Effects to full intensity for 100 ms.
+* Snare hits push Overhead Effects to full intensity for 100 ms in addition to the VU-driven level.
 * Moving head executes wide, energetic sweeps.
 * **3-second smoke burst** every **30 seconds**.
 

--- a/main.py
+++ b/main.py
@@ -347,10 +347,15 @@ class BeatDMXShow:
 
     def _update_overhead_from_vu(self, _ctrl: DMX) -> None:
         """Set Overhead Effects dimmer based on the latest VU reading."""
+        now = time.time()
+        end = self.beat_ends.get("Overhead Effects", 0.0)
+        if now < end:
+            return
+
         level = int(min(1.0, self.current_vu / parameters.VU_FULL) * 255)
         if self.log_file:
             self.log_file.write(
-                f"{time.time():.3f} VU:{self.current_vu:.3f} dimmer:{level}\n"
+                f"{now:.3f} VU:{self.current_vu:.3f} dimmer:{level}\n"
             )
             self.log_file.flush()
         if level != self.last_vu_dimmer:


### PR DESCRIPTION
## Summary
- avoid overwriting snare flash when updating VU level
- clarify snare flash behaviour in docs

## Testing
- `pip install -i https://pypi.org/simple --extra-index-url https://pypi.org/simple sounddevice aubio numpy scipy pyserial librosa transformers`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68715b910084832996bd69b6e4c4ec04