### PR TITLE
Switch genre detection to AI model

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,12 @@ This project contains utilities to drive DMX lights and detect beats from microp
 
 ## Beat-controlled blinking
 
-The `beat_dmx.py` script listens to microphone input, detects beats using `aubio`,
-and blinks a chosen DMX channel every time a beat is found. It periodically
-prints a summary of the estimated BPM and a rough music genre classification
-every 10 seconds based on adjustable BPM ranges. BPM is derived from the median
-of the most recent beat intervals, which helps smooth out occasional
-mis-detected beats. The detector also provides lightweight heuristics for chorus,
-crescendo
-and drum solo detection using spectral features with a 0.5-second debounce.
+The `beat_dmx.py` script listens to microphone input, detects beats using
+`aubio`, and blinks a chosen DMX channel on each beat. It prints the estimated
+BPM every few seconds and runs a genre classifier based on the
+`music_genres_classification` transformer model. The detector also provides
+lightweight heuristics for chorus, crescendo and drum solo detection using a
+0.5-second debounce.
 
 ### Usage
 

--- a/main.py
+++ b/main.py
@@ -219,10 +219,6 @@ class BeatDMXShow:
         updates.pop("Smoke Machine", None)
         self._print_state_change(updates)
 
-    @staticmethod
-    def _detect_genre(bpm: float) -> parameters.Scenario:
-        """Return scenario for this BPM using ``parameters`` ranges."""
-        return parameters.scenario_for_bpm(bpm)
 
     def _start_genre_classification(self) -> None:
         if self.classifying or not self.audio_buffer:
@@ -290,8 +286,8 @@ class BeatDMXShow:
 
     def _handle_beat(self, bpm: float, now: float) -> None:
         if bpm:
-            genre = self.last_genre or self._detect_genre(bpm)
-            line = f"Beat at {bpm:.2f} BPM - genre {genre.value}"
+            label = self._genre_label(self.last_genre)
+            line = f"Beat at {bpm:.2f} BPM" + (f" - genre {label}" if label else "")
             if self.dashboard_enabled:
                 self.dashboard.set_bpm(bpm)
             else:
@@ -300,11 +296,6 @@ class BeatDMXShow:
                     prefix = "\r" if self._beat_line is not None else ""
                     print(prefix + line + pad, end="", flush=True)
                     self._beat_line = line
-            if self.last_genre is None and self.scenario != genre:
-                if self.current_state == SongState.ONGOING:
-                    self._set_scenario(genre)
-                if self.dashboard_enabled and self.current_state != SongState.INTERMISSION:
-                    self.dashboard.set_genre(self._genre_label(genre))
 
             if (
                 not self.smoke_on


### PR DESCRIPTION
## Summary
- rely solely on the transformer-based genre classifier
- drop fallback BPM-based genre guessing
- document updated classification approach

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687160a365f883299219f13d409226bb