### PR TITLE
Improve offline genre classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ You can tweak this debounce time by editing the ``BeatDetector``
 ## Genre classification
 
 When a song begins, audio from the first few seconds feeds a pre-trained
-`music_genres_classification` model via the Transformers pipeline. The predicted
+`music_genres_classification` model via the Transformers pipeline. The
+classifier loads the model from `models/music_genres_classification`. The
+predicted
 label selects the closest lighting scenario:
 
 - rock -> Song Ongoing - Rock

--- a/src/audio/genre_classifier.py
+++ b/src/audio/genre_classifier.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from transformers import pipeline
 import numpy as np
 
@@ -7,13 +8,22 @@ import numpy as np
 class GenreClassifier:
     """Wrapper around a pre-trained genre classification pipeline."""
 
-    def __init__(self, model_name: str = "dima806/music_genres_classification") -> None:
-        self.model_name = model_name
+    def __init__(self, model_path: str | Path | None = None) -> None:
+        if model_path is None:
+            root_dir = Path(__file__).resolve().parents[2]
+            model_path = root_dir / "models" / "music_genres_classification"
+        self.model_path = Path(model_path)
+        if not self.model_path.exists():
+            raise FileNotFoundError(f"Genre model not found at {self.model_path}")
         self._classifier = None
 
     def classify(self, samples: np.ndarray, samplerate: int) -> str:
         """Return the top predicted genre label for the given audio."""
         if self._classifier is None:
-            self._classifier = pipeline("audio-classification", model=self.model_name)
+            self._classifier = pipeline(
+                "audio-classification",
+                model=str(self.model_path),
+                local_files_only=True,
+            )
         result = self._classifier({"array": samples, "sampling_rate": samplerate})[0]
         return result["label"]


### PR DESCRIPTION
## Summary
- look for the local `models/music_genres_classification` directory and require it
- note the fixed model path in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871655bb3f08329a9746e1f8f3b2b11