### PR TITLE
Fix genre detection dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ heuristics for chorus, crescendo and drum solo detection using a
 
 ```bash
 pip install -r requirements.txt
+pip install torch  # required for genre classification
 python beat_dmx.py --universe 1 --channel 1
 ```
 
@@ -68,6 +69,7 @@ If you just want to detect beats without sending DMX commands, use `beat_detecti
 
 ```bash
 pip install -r requirements.txt
+pip install torch
 python beat_detection.py
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scipy
 pyserial
 librosa
 transformers
+torch

--- a/src/audio/genre_classifier.py
+++ b/src/audio/genre_classifier.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from transformers import pipeline
+from transformers import pipeline, is_torch_available, is_tf_available
 import numpy as np
 
 
@@ -14,6 +14,11 @@ class GenreClassifier:
         self.model_path = Path(model_path)
         if not self.model_path.exists():
             raise FileNotFoundError(f"Genre model not found at {self.model_path}")
+
+        if not is_torch_available() and not is_tf_available():
+            raise ImportError(
+                "PyTorch or TensorFlow is required for genre classification"
+            )
 
         self._classifier = None
 


### PR DESCRIPTION
## Summary
- ensure `GenreClassifier` checks for a supported framework
- require `torch` in requirements
- mention installing torch in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687169f07e4883298725dd822689bd26