### PR TITLE
Fix AI log duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ readings. Chorus, drum solo and crescendo flags appear alongside the song
 state and detected genre at the top.
 Running the show writes VU and dimmer levels to ``vu_dimmer.log`` for debugging.
 Genre classifier details are also logged to ``ai.log``. The file begins with a
-status line noting whether the genre classifier loaded successfully.
+status line noting whether the genre classifier loaded successfully. Messages
+appear only once even if both the show and classifier write to the same file.
 
 ## Standalone beat detection
 

--- a/main.py
+++ b/main.py
@@ -163,7 +163,7 @@ class BeatDMXShow:
         self.ai_log_handle = open(self.ai_log_path, "a")
         if genre_model is _GENRE_SENTINEL:
             from src.audio import GenreClassifier as GC
-            self.genre_classifier = GC(log_file=self.ai_log_path, verbose=True)
+            self.genre_classifier = GC(log_file=self.ai_log_handle, verbose=True)
         else:
             self.genre_classifier = genre_model
         if self.genre_classifier is None:

--- a/src/audio/genre_classifier.py
+++ b/src/audio/genre_classifier.py
@@ -13,7 +13,7 @@ class GenreClassifier:
         self,
         model_path: str | Path | None = None,
         verbose: bool = False,
-        log_file: str | Path | None = None,
+        log_file: str | Path | TextIO | None = None,
     ) -> None:
         if model_path is None:
             root_dir = Path(__file__).resolve().parents[2]
@@ -30,8 +30,13 @@ class GenreClassifier:
         self._classifier = None
         self.verbose = verbose
         self.log_file: TextIO | None = None
+        self._own_log = False
         if log_file is not None:
-            self.log_file = open(log_file, "a")
+            if hasattr(log_file, "write"):
+                self.log_file = log_file  # type: ignore[assignment]
+            else:
+                self.log_file = open(log_file, "a")
+                self._own_log = True
 
     def _log(self, message: str) -> None:
         if self.log_file:
@@ -61,7 +66,7 @@ class GenreClassifier:
         return label
 
     def __del__(self) -> None:
-        if self.log_file:
+        if self._own_log and self.log_file:
             try:
                 self.log_file.close()
             except Exception:

--- a/tests/test_genre_classifier.py
+++ b/tests/test_genre_classifier.py
@@ -6,3 +6,18 @@ def test_scenario_mapping():
     show = BeatDMXShow(genre_model=None)
     assert show._scenario_from_label("rock") == Scenario.SONG_ONGOING_ROCK
     assert show._scenario_from_label("classical") == Scenario.SONG_ONGOING_SLOW
+
+
+def test_ai_log_single_entry(tmp_path, monkeypatch):
+    log_file = tmp_path / "ai.log"
+
+    class DummyGC:
+        def __init__(self, log_file=None, verbose=False):
+            self.log_file = log_file
+
+    monkeypatch.setattr("src.audio.GenreClassifier", DummyGC)
+    show = BeatDMXShow(ai_log_path=str(log_file))
+    show._ai_log("entry")
+    show.ai_log_handle.close()
+    contents = log_file.read_text().splitlines()
+    assert contents == ["AI logging started", "entry"]


### PR DESCRIPTION
## Summary
- avoid opening ai.log twice in `BeatDMXShow`
- allow `GenreClassifier` to accept a file handle instead of a path
- close genre classifier log only if we opened it
- document AI log behavior and add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687178f2c4388329b21165a1835ade5f