### PR TITLE
Add detailed AI logging

### DIFF
--- a/dmx.py
+++ b/dmx.py
@@ -1,0 +1,1 @@
+from src.dmx.dmx import *

--- a/tests/test_genre_classifier.py
+++ b/tests/test_genre_classifier.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from parameters import Scenario
 from main import BeatDMXShow
 
@@ -15,7 +20,11 @@ def test_ai_log_single_entry(tmp_path, monkeypatch):
         def __init__(self, log_file=None, verbose=False):
             self.log_file = log_file
 
-    monkeypatch.setattr("src.audio.GenreClassifier", DummyGC)
+    import types, sys
+    import src.audio as audio
+
+    sys.modules["src.audio.genre_classifier"] = types.SimpleNamespace(GenreClassifier=DummyGC)
+    audio.GenreClassifier = DummyGC
     show = BeatDMXShow(ai_log_path=str(log_file))
     show._ai_log("entry")
     show.ai_log_handle.close()


### PR DESCRIPTION
## Summary
- improve ai.log output for state changes and scenario transitions
- log reasons why genre classification gets skipped
- expose DMX package as `dmx` for tests
- update tests to avoid heavy imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872387d43848329903078a810ce6b31