### PR TITLE
Reset genre state between songs

### DIFF
--- a/main.py
+++ b/main.py
@@ -328,6 +328,8 @@ class BeatDMXShow:
         self._set_scenario(mapping.get(state, Scenario.INTERMISSION))
         if state == SongState.STARTING:
             self.audio_buffer.clear()
+            self.last_genre = None
+            self.genre_label = ""
         elif state == SongState.ONGOING:
             self._start_genre_classification()
         self.current_state = state


### PR DESCRIPTION
## Summary
- clear last_genre and genre_label when a new song starts so classification can run again

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68723ee43cf88329a81b46752b92cdeb