### PR TITLE
Add status and proposals to work items

### DIFF
--- a/workitems/002-story-beat-driven-lighting.md
+++ b/workitems/002-story-beat-driven-lighting.md
@@ -5,7 +5,7 @@
 Beat-driven lighting scenarios
 
 # State
-New
+Active
 
 # User Story
 As a Karaoke Host, I want the lights to react to beats and song states so that the
@@ -21,5 +21,7 @@ show energy matches the music.
 
 # Implementation Proposal
 
-
+* Integrate beat detection events with the scenario engine.
+* Map each beat to DMX group updates defined in `parameters.py`.
+* Ensure state transitions continue to follow the song state machine.
 

--- a/workitems/003-story-dashboard-monitor.md
+++ b/workitems/003-story-dashboard-monitor.md
@@ -5,7 +5,7 @@
 Dashboard shows real-time audio and lighting status
 
 # State
-New
+Active
 
 # User Story
 As a Karaoke Host, I want a console dashboard that displays BPM, VU and cue states
@@ -21,5 +21,7 @@ so that I can monitor the show at a glance.
 
 # Implementation Proposal
 
-
+* Build a curses-based dashboard to render BPM, VU and scenario data.
+* Update the display each loop using metrics from the main application.
+* Highlight chorus and crescendo flags with minimal flicker.
 

--- a/workitems/004-story-genre-classification.md
+++ b/workitems/004-story-genre-classification.md
@@ -5,7 +5,7 @@
 Genre classification sets lighting scenarios
 
 # State
-New
+Active
 
 # User Story
 As a Karaoke Host, I want the show to classify the music genre so that lighting
@@ -22,5 +22,7 @@ changes to a matching scenario automatically.
 
 # Implementation Proposal
 
-
+* Buffer five seconds of audio before launching the genre classifier thread.
+* Map the resulting label to a scenario with `_scenario_from_label`.
+* If no label is returned, fall back to `scenario_for_bpm`.
 

--- a/workitems/005-story-blink-red-script (Closed).md
+++ b/workitems/005-story-blink-red-script (Closed).md
@@ -21,5 +21,7 @@ DMX output without running the full show.
 
 # Implementation Proposal
 
-
+* Script pulses a LumiPar 7UTRI red using simple DMX write calls.
+* Accept CLI options for serial port, starting address and blink count.
+* Print usage help when required arguments are missing.
 

--- a/workitems/006-story-bpm-fallback.md
+++ b/workitems/006-story-bpm-fallback.md
@@ -5,7 +5,7 @@
 Apply BPM-based scenario when genre is unknown
 
 # State
-New
+Active
 
 # User Story
 As a Karaoke Host, I want the show to select a scenario by BPM if genre
@@ -21,5 +21,7 @@ classification fails so that lighting does not remain stuck in Song Start.
 
 # Implementation Proposal
 
-
+* Add a `scenario_for_bpm(bpm)` helper that maps tempo ranges to scenarios.
+* When genre classification fails, call this helper using the current BPM.
+* Replace the scenario if a genre label arrives later.
 

--- a/workitems/007-story-extended-ai-log.md
+++ b/workitems/007-story-extended-ai-log.md
@@ -5,7 +5,7 @@
 Timestamped AI log with beat entries
 
 # State
-New
+Active
 
 # User Story
 As a Karaoke Host, I want `ai.log` to include timestamps and occasional BPM lines so
@@ -21,5 +21,7 @@ that I can trace show behavior after a performance.
 
 # Implementation Proposal
 
-
+* Add a helper function that writes timestamped lines to `ai.log`.
+* Call this helper for all console messages and periodic BPM reports.
+* Keep each log entry under 100 characters for readability.
 

--- a/workitems/008-story-timer-based-scenarios.md
+++ b/workitems/008-story-timer-based-scenarios.md
@@ -5,7 +5,7 @@
 Support timer-based color transitions in scenarios
 
 # State
-New
+Active
 
 # User Story
 As a Karaoke Host, I want scenarios to define beat, chorus and timed color
@@ -21,5 +21,7 @@ changes so that complex cues run without code changes.
 
 # Implementation Proposal
 
-
+* Extend scenario definitions with a `timer` section for timed transitions.
+* Schedule color fades using the main loop and current DMX FPS value.
+* Combine timer events with beat or chorus triggers for complex cues.
 


### PR DESCRIPTION
## Summary
- mark user stories active rather than new
- detail implementation for each story
- leave the bug item unchanged

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687253af5314832988dec88bbb7dea7a