### PR TITLE
Improve genre classifier trigger

### DIFF
--- a/main.py
+++ b/main.py
@@ -499,6 +499,14 @@ class BeatDMXShow:
             )
             if now - self.buffer_start_time >= 5.0:
                 self.buffering = False
+            elif (
+                len(self.pre_song_buffer) >= self.pre_song_buffer.maxlen
+                and not self.classifying
+            ):
+                # Enough audio collected, start classification early
+                self.classify_after = None
+                self.buffering = False
+                self._launch_genre_classifier_immediately()
         if (
             self.classify_after is not None
             and now >= self.classify_after


### PR DESCRIPTION
## Summary
- launch the genre classifier as soon as 5 seconds of audio are buffered
- keep current timer-based launch but start early when the buffer fills

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68726602eee483299757d06ee610b7b7