### PR TITLE
Fix genre classification trigger

### DIFF
--- a/check_classifier.py
+++ b/check_classifier.py
@@ -1,0 +1,28 @@
+from transformers import pipeline
+import numpy as np
+
+print("✅ transformers imported")
+
+try:
+    import torch
+    print("✅ torch available: version", torch.__version__)
+except ImportError:
+    print("❌ torch not installed")
+
+try:
+    import torchaudio
+    print("✅ torchaudio available")
+except ImportError:
+    print("❌ torchaudio not installed")
+
+print("Loading model pipeline...")
+classifier = pipeline(
+    "audio-classification",
+    model="models/music_genres_classification",
+    local_files_only=True,
+)
+print("✅ pipeline loaded")
+
+samples = np.sin(2 * np.pi * 440 * np.linspace(0, 1, 16000))
+result = classifier({"array": samples, "sampling_rate": 16000})
+print("Prediction:", result)


### PR DESCRIPTION
## Summary
- trigger genre classifier as soon as song enters ONGOING
- add detailed logs for classifier launch and thread lifecycle
- include utility script `check_classifier.py` to verify model dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872771047e88329b9eaa87776825a96