### PR TITLE
Update scenario transitions

### DIFF
--- a/parameters.py
+++ b/parameters.py
@@ -311,6 +311,10 @@ def _resolve_transitions() -> None:
         sc.successors = [lookup[n] for n in sc.successor_names]
         del sc.predecessor_names
         del sc.successor_names
+    # Prevent Song Start from transitioning directly to Intermission
+    intermission = lookup["INTERMISSION"]
+    if Scenario.SONG_START in intermission.predecessors:
+        intermission.predecessors.remove(Scenario.SONG_START)
 
 
 _resolve_transitions()


### PR DESCRIPTION
## Summary
- remove Song Start predecessor from Intermission after resolving transitions
- keep Intermission from being reachable directly from Song Start

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68727cb6dd8483298fdb7b7444622eb3