### PR TITLE
Fix scenario transition guard

### DIFF
--- a/main.py
+++ b/main.py
@@ -261,8 +261,8 @@ class BeatDMXShow:
         current = self.scenario
         if (
             not force
-            and name != current
-            and (current not in name.predecessors or name not in current.successors)
+            and scn != current
+            and (current not in scn.predecessors or scn not in current.successors)
         ):
             return
         if scn != self.scenario:

--- a/workitems/009-bug-song-start-intermission (Active).md
+++ b/workitems/009-bug-song-start-intermission (Active).md
@@ -1,0 +1,41 @@
+# Work Item ID
+009
+
+# Title
+Song Start transitions back to Intermission unexpectedly
+
+# State
+Active
+
+# Description
+After a song starts the lights enter the Song Start scenario. A moment later
+Intermission is triggered again even though this transition is disallowed.
+
+# Steps to Reproduce
+1. Run `python main.py`.
+2. Play a short burst of loud audio.
+3. Watch the console log: "State changed to Starting" then "State changed to
+   Intermission".
+4. Intermission lighting values are applied despite never reaching Song Ending.
+
+# Expected vs. Actual Results
+Expected: The Song Start scenario stays active until the song reaches Ending or a
+valid successor.
+Actual: The scenario reverts directly to Intermission.
+
+# Proposed Fix
+`_set_scenario` checks allowed transitions using the incoming value `name`. When
+`name` is not the canonical enum instance the comparison fails, letting the
+change through. Compare using the resolved variable `scn` instead:
+
+```python
+current = self.scenario
+if (
+    not force
+    and scn != current
+    and (current not in scn.predecessors or scn not in current.successors)
+):
+    return
+```
+
+This enforces the intended transition rules.


### PR DESCRIPTION
## Summary
- use resolved scenario when checking allowed transitions
- record bug reproduction in work items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687283db1b748329ba3b2669b1ef2a9d