### PR TITLE
Improve genre classification reliability

### DIFF
--- a/main.py
+++ b/main.py
@@ -309,13 +309,8 @@ class BeatDMXShow:
             if song_id == self.song_id:
                 self.genre_label = label
                 if label == "":
-                    scenario = parameters.scenario_for_bpm(self.last_bpm)
-                    log.info(
-                        "THREAD fallback    song_id=%s  bpm=%.2f  scenario=%s",
-                        song_id,
-                        self.last_bpm,
-                        scenario,
-                    )
+                    log.info("THREAD empty label, defaulting to slow scenario")
+                    scenario = Scenario.SONG_ONGOING_SLOW
                 self.last_genre = scenario
                 if self.current_state == SongState.ONGOING:
                     self._set_scenario(scenario)

--- a/src/audio/genre_classifier.py
+++ b/src/audio/genre_classifier.py
@@ -8,6 +8,7 @@ import log
 log = logging.getLogger("AI")
 from transformers import pipeline, is_torch_available, is_tf_available
 import numpy as np
+import librosa
 
 
 class GenreClassifier:
@@ -62,6 +63,12 @@ class GenreClassifier:
         self._log(
             f"classify: samples={samples.shape} samplerate={samplerate}"
         )
+        if samplerate != 16000:
+            self._log(
+                f"Resampling from {samplerate}Hz to 16000Hz for classifier"
+            )
+            samples = librosa.resample(samples, orig_sr=samplerate, target_sr=16000)
+            samplerate = 16000
         result = self._classifier({"array": samples, "sampling_rate": samplerate})
         if not result:
             self._log("genre model returned no predictions")

--- a/tests/test_genre_classifier.py
+++ b/tests/test_genre_classifier.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from parameters import Scenario, scenario_for_bpm
+from parameters import Scenario
 from main import BeatDMXShow
 import log
 import numpy as np
@@ -32,23 +32,5 @@ def test_ai_log_single_entry(monkeypatch):
     assert any("AI logging started" in line for line in contents)
     assert "entry" in contents[-1]
 
-
-def test_fallback_scenario(monkeypatch):
-
-    class DummyGC:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def classify(self, samples, sr):
-            return ""
-
-    import src.audio as audio
-
-    monkeypatch.setattr(audio, "GenreClassifier", DummyGC)
-    show = BeatDMXShow(genre_model=DummyGC())
-    show.last_bpm = 120.0
-    samples = np.zeros(10, dtype=np.float32)
-    show._run_genre_classifier(samples, show.samplerate, show.song_id)
-    assert show.last_genre == scenario_for_bpm(120.0)
 
 


### PR DESCRIPTION
## Summary
- remove BPM-based genre fallback logic
- resample audio to 16kHz before genre classification
- default to slow scenario if the classifier returns an empty label
- clean up tests accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a8a910588329b3ef897b5d6de1d4