### PR TITLE
Enable debug log by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Running the show writes VU and dimmer levels to ``vu_dimmer.log`` for debugging.
 Genre classifier details are also logged to ``ai.log``. The file begins with a
 status line noting whether the genre classifier loaded successfully. Messages
 appear only once even if both the show and classifier write to the same file.
-Enable ``debug_log_path`` on ``BeatDMXShow`` to capture extra runtime details in
-``debug.log``.
+Runtime details are logged to ``logs/debug.log`` by default; set
+``debug_log_path`` to override the location.
 
 ## Standalone beat detection
 


### PR DESCRIPTION
## Summary
- log configuration module is imported under `log_config`
- create a debug log file by default at `logs/debug.log`
- update README to mention the new default

## Testing
- `pip install numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ae26dcf08329a66e611d6c20093a