### PR TITLE
Clarify ongoing transition logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -390,6 +390,11 @@ class BeatDMXShow:
         return Scenario.SONG_ONGOING_SLOW
 
     def _handle_state_change(self, state: SongState) -> None:
+        prev_state = self.current_state
+        if state == SongState.ONGOING and self.last_genre is None:
+            logger.debug("Ignore Ongoing transition until genre classified")
+            return
+
         self._flush_beat_line()
         if self.dashboard_enabled:
             self.dashboard.set_state(state.value)
@@ -400,7 +405,7 @@ class BeatDMXShow:
         self._debug_log(f"State changed to {state.value}")
         logger.info(
             "STATE change %s -> %s  | last_genre=%s  classifying=%s",
-            self.current_state,
+            prev_state,
             state,
             self.last_genre,
             self.classifying,


### PR DESCRIPTION
## Summary
- ignore transitions to ONGOING until a genre is detected
- log state changes only after a successful transition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68736d5fb8f48329b0c03e551272fa9e