### PR TITLE
Fix SongState identity mismatch

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency for tests
     sd = None
 
-from src.audio import SongState
+from src.audio.beat_detection import SongState
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Summary
- import `SongState` from `src.audio.beat_detection` rather than the lightweight
  copy in `src.audio.__init__`

This ensures comparisons with `BeatDetector` states work and scenarios map
correctly.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687371b1717c83299b5e42e763c8ae02