### PR TITLE
Fix genre classifier logging bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -358,7 +358,7 @@ class BeatDMXShow:
         sid = self.song_id
         logger.info(
             "LAUNCH classifier thread, %d samples in buffer",
-            sum(len(b) for b in self.pre_song_buffer),
+            len(self.pre_song_buffer),
         )
         logger.info(
             "LAUNCH classifier  song_id=%s  frames=%d  secs=%.2f",


### PR DESCRIPTION
## Summary
- avoid calling `len()` on float samples in genre classifier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687374ba84b4832982ca070bbd93b49d