### PR TITLE
Add per-genre ongoing scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ python blink_red.py --port /dev/ttyUSB0 --start-address 1 --blink-times 3
 
 `beat_dmx.py` simply blinks one channel whenever a beat is detected. It prints
 the estimated BPM every few seconds. LumiPar 12UAW5 units double as house
-lights and overhead effects pulse with BPM. Smoke bursts last 3 seconds with a
+lights and overhead effects respond to the current genre. Smoke bursts last 3 seconds with a
 30-second gap. The moving head stays on the artist during songs and points at
 the audience to end each song. Stage lights fade to black during songs and
 return at 50% warm white when the moving head faces the crowd.
@@ -81,7 +81,7 @@ python beat_detection.py
 Output is limited to a short summary printed every 10 seconds to avoid
 performance issues when detecting rapid beats. Each summary also prints the
 current stage lighting state and whether smoke bursts are firing. LumiPar 12UAW5
-units double as house lights, overhead effects pulse with BPM and smoke bursts
+units double as house lights, overhead effects track the detected genre and smoke bursts
 last 3 seconds with a 30-second gap.
 
 The detector will also analyze the incoming volume (VU level) to determine when a
@@ -118,11 +118,16 @@ classifier loads the model from `models/music_genres_classification`. The
 predicted
 label selects the closest lighting scenario:
 
-- rock -> Song Ongoing - Rock
+- disco -> Song Ongoing - Disco
 - metal -> Song Ongoing - Metal
+- reggae -> Song Ongoing - Reggae
+- blues -> Song Ongoing - Blues
+- rock -> Song Ongoing - Rock
+- classical -> Song Ongoing - Classical
 - jazz -> Song Ongoing - Jazz
-- pop/disco -> Song Ongoing - Pop
-- blues, country, reggae or classical -> Song Ongoing - Slow
+- hiphop -> Song Ongoing - HipHop
+- country -> Song Ongoing - Country
+- pop -> Song Ongoing - Pop
 
 This model runs in a background thread so beat detection remains responsive.
 If the genre remains blank, create ``GenreClassifier(verbose=True)`` to see
@@ -163,8 +168,8 @@ equal RGB values so scenarios need no manual changes.
 
 ## Show
 
-Lighting cues are BPM-driven. LumiPar 12UAW5 units double as house lights.
-Overheads pulse with BPM and smoke bursts last 3 seconds with a 30-second gap.
+Lighting cues follow the AI-detected genre. LumiPar 12UAW5 units double as house lights.
+Overhead effects respond to the current genre and smoke bursts last 3 seconds with a 30-second gap.
 Beat updates briefly change overhead colors for 100 ms on each beat.
 Genre-specific colors guide intensity and timing. The moving head stays on the
 artist during songs and aims at the audience to end each song. Stage lights fade

--- a/main.py
+++ b/main.py
@@ -376,17 +376,28 @@ class BeatDMXShow:
     @staticmethod
     def _scenario_from_label(label: str) -> Scenario:
         """Map model label to a show scenario."""
-        lbl = label.lower()
+        lbl = label.lower().strip()
+        lbl = parameters.GENRE_ID_MAP.get(lbl, lbl)
         if "rock" in lbl:
             return Scenario.SONG_ONGOING_ROCK
         if "metal" in lbl:
             return Scenario.SONG_ONGOING_METAL
         if "jazz" in lbl:
             return Scenario.SONG_ONGOING_JAZZ
-        if "pop" in lbl or "disco" in lbl:
+        if "pop" in lbl:
             return Scenario.SONG_ONGOING_POP
-        if lbl in {"blues", "country", "reggae", "classical", "hip hop", "hip-hop"}:
-            return Scenario.SONG_ONGOING_SLOW
+        if "disco" in lbl:
+            return Scenario.SONG_ONGOING_DISCO
+        if "reggae" in lbl:
+            return Scenario.SONG_ONGOING_REGGAE
+        if "blues" in lbl:
+            return Scenario.SONG_ONGOING_BLUES
+        if "classical" in lbl:
+            return Scenario.SONG_ONGOING_CLASSICAL
+        if "country" in lbl:
+            return Scenario.SONG_ONGOING_COUNTRY
+        if any(x in lbl for x in ["hip hop", "hip-hop", "hiphop"]):
+            return Scenario.SONG_ONGOING_HIPHOP
         return Scenario.SONG_ONGOING_SLOW
 
     def _handle_state_change(self, state: SongState) -> None:

--- a/parameters.py
+++ b/parameters.py
@@ -41,6 +41,20 @@ COM_PORT = "COM4"
 # How many DMX frames to send per second
 DMX_FPS = 30
 
+# Mapping from numeric genre IDs to label strings
+GENRE_ID_MAP = {
+    "0": "disco",
+    "1": "metal",
+    "2": "reggae",
+    "3": "blues",
+    "4": "rock",
+    "5": "classical",
+    "6": "jazz",
+    "7": "hiphop",
+    "8": "country",
+    "9": "pop",
+}
+
 # List of (fixture class, start_address, name) tuples describing the rig
 DEVICES = [
     #(Prolights_LumiPar12UAW5_7ch, 1, "House Lights"),
@@ -282,6 +296,113 @@ class Scenario(Enum):
             },
         },
     )
+    SONG_ONGOING_DISCO = (
+        "Song Ongoing - Disco",
+        0.02,
+        (110, 130),
+        [],
+        [],
+        {
+            "House Lights": {"dimmer": 0},
+            "Moving Head": {"dimmer": 255},
+            "Overhead Effects": {"red": 255, "blue": 96, "dimmer": 255},
+            "Karaoke Lights": {"red": 26, "blue": 10, "dimmer": 26},
+            "Smoke Machine": {"smoke_gap": 10000, "duration": 5000},
+        },
+        {
+            "Overhead Effects": {
+                "red": 255,
+                "blue": 96,
+                "dimmer": 255,
+                "duration": 100,
+            },
+        },
+    )
+    SONG_ONGOING_REGGAE = (
+        "Song Ongoing - Reggae",
+        0.02,
+        (0, 80),
+        [],
+        [],
+        {
+            "House Lights": {"dimmer": 0},
+            "Moving Head": {"dimmer": 255},
+            "Overhead Effects": {"red": 255, "dimmer": 255},
+            "Karaoke Lights": {"red": 26, "dimmer": 26},
+            "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
+        },
+        {
+            "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100},
+        },
+    )
+    SONG_ONGOING_BLUES = (
+        "Song Ongoing - Blues",
+        0.02,
+        (0, 80),
+        [],
+        [],
+        {
+            "House Lights": {"dimmer": 0},
+            "Moving Head": {"dimmer": 255},
+            "Overhead Effects": {"red": 255, "dimmer": 255},
+            "Karaoke Lights": {"red": 26, "dimmer": 26},
+            "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
+        },
+        {
+            "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100},
+        },
+    )
+    SONG_ONGOING_CLASSICAL = (
+        "Song Ongoing - Classical",
+        0.02,
+        (0, 80),
+        [],
+        [],
+        {
+            "House Lights": {"dimmer": 0},
+            "Moving Head": {"dimmer": 255},
+            "Overhead Effects": {"red": 255, "dimmer": 255},
+            "Karaoke Lights": {"red": 26, "dimmer": 26},
+            "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
+        },
+        {
+            "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100},
+        },
+    )
+    SONG_ONGOING_HIPHOP = (
+        "Song Ongoing - HipHop",
+        0.02,
+        (0, 80),
+        [],
+        [],
+        {
+            "House Lights": {"dimmer": 0},
+            "Moving Head": {"dimmer": 255},
+            "Overhead Effects": {"red": 255, "dimmer": 255},
+            "Karaoke Lights": {"red": 26, "dimmer": 26},
+            "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
+        },
+        {
+            "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100},
+        },
+    )
+    SONG_ONGOING_COUNTRY = (
+        "Song Ongoing - Country",
+        0.02,
+        (0, 80),
+        [],
+        [],
+        {
+            "House Lights": {"dimmer": 0},
+            "Moving Head": {"dimmer": 255},
+            "Overhead Effects": {"red": 255, "dimmer": 255},
+            "Karaoke Lights": {"red": 26, "dimmer": 26},
+            "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
+        },
+        {
+            "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100},
+        },
+    )
     SONG_ENDING = (
         "Song Ending",
         0.02,
@@ -304,6 +425,15 @@ class Scenario(Enum):
     )
 
 
+def _add_ongoing_transitions() -> None:
+    names = [sc.name for sc in Scenario if sc.name.startswith("SONG_ONGOING")]
+    for sc in Scenario:
+        if sc.name.startswith("SONG_ONGOING"):
+            others = [n for n in names if n != sc.name]
+            sc.predecessor_names = ["SONG_START"] + others
+            sc.successor_names = others + ["SONG_ENDING"]
+
+
 def _resolve_transitions() -> None:
     lookup = {sc.name: sc for sc in Scenario}
     for sc in Scenario:
@@ -313,6 +443,7 @@ def _resolve_transitions() -> None:
         del sc.successor_names
 
 
+_add_ongoing_transitions()
 _resolve_transitions()
 
 # Mapping for quick lookup by name

--- a/tests/test_genre_classifier.py
+++ b/tests/test_genre_classifier.py
@@ -12,7 +12,22 @@ import numpy as np
 def test_scenario_mapping():
     show = BeatDMXShow(genre_model=None)
     assert show._scenario_from_label("rock") == Scenario.SONG_ONGOING_ROCK
-    assert show._scenario_from_label("classical") == Scenario.SONG_ONGOING_SLOW
+    assert show._scenario_from_label("classical") == Scenario.SONG_ONGOING_CLASSICAL
+
+    expected = {
+        "0": Scenario.SONG_ONGOING_DISCO,
+        "1": Scenario.SONG_ONGOING_METAL,
+        "2": Scenario.SONG_ONGOING_REGGAE,
+        "3": Scenario.SONG_ONGOING_BLUES,
+        "4": Scenario.SONG_ONGOING_ROCK,
+        "5": Scenario.SONG_ONGOING_CLASSICAL,
+        "6": Scenario.SONG_ONGOING_JAZZ,
+        "7": Scenario.SONG_ONGOING_HIPHOP,
+        "8": Scenario.SONG_ONGOING_COUNTRY,
+        "9": Scenario.SONG_ONGOING_POP,
+    }
+    for digit, scenario in expected.items():
+        assert show._scenario_from_label(digit) == scenario
 
 
 def test_ai_log_single_entry(monkeypatch):


### PR DESCRIPTION
## Summary
- add per-genre ongoing scenarios
- map classifier labels and digit IDs 0-9 1:1 to scenarios
- include fallback transitions across all Song Ongoing states
- document that lighting now follows the AI-detected genre

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737830658883298e0f3eb3974cf32b