### PR TITLE
Add periodic genre updates

### DIFF
--- a/parameters.py
+++ b/parameters.py
@@ -41,6 +41,9 @@ COM_PORT = "COM4"
 # How many DMX frames to send per second
 DMX_FPS = 30
 
+# Seconds between automatic genre classification checks
+GENRE_CHECK_INTERVAL = 15.0
+
 # Mapping from numeric genre IDs to label strings
 GENRE_ID_MAP = {
     "0": "disco",


### PR DESCRIPTION
## Summary
- poll for genre every 15 seconds
- record timestamp of each genre check
- collect audio for classification continuously
- expose `GENRE_CHECK_INTERVAL` parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68738141db408329b8c07f61988e4340