### PR TITLE
Update scenario lighting mood settings

### DIFF
--- a/parameters.py
+++ b/parameters.py
@@ -219,17 +219,12 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "green": 96, "dimmer": 255},
-            "Karaoke Lights": {"red": 26, "green": 10, "dimmer": 26},
-            "Smoke Machine": {"smoke_gap": 30000, "duration": 5000},
+            "Overhead Effects": {"red": 255, "blue": 255, "dimmer": 255},
+            "Karaoke Lights": {"red": 26, "blue": 26, "dimmer": 26},
+            "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {
-                "red": 255,
-                "green": 96,
-                "dimmer": 255,
-                "duration": 100,
-            },
+            "Overhead Effects": {"red": 255, "blue": 255, "dimmer": 255, "duration": 100},
         },
     )
     SONG_ONGOING_POP = (
@@ -265,17 +260,12 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "blue": 96, "dimmer": 255},
-            "Karaoke Lights": {"red": 26, "blue": 10, "dimmer": 26},
-            "Smoke Machine": {"smoke_gap": 10000, "duration": 5000},
+            "Overhead Effects": {"green": 255, "dimmer": 255},
+            "Karaoke Lights": {"green": 26, "dimmer": 26},
+            "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {
-                "red": 255,
-                "blue": 96,
-                "dimmer": 255,
-                "duration": 100,
-            },
+            "Overhead Effects": {"green": 255, "dimmer": 255, "duration": 100},
         },
     )
     SONG_ONGOING_ROCK = (
@@ -311,16 +301,12 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "dimmer": 255},
-            "Karaoke Lights": {"red": 26, "dimmer": 26},
-            "Smoke Machine": {"smoke_gap": 20000, "duration": 5000},
+            "Overhead Effects": {"red": 255, "green": 64, "dimmer": 255},
+            "Karaoke Lights": {"red": 26, "green": 6, "dimmer": 26},
+            "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {
-                "red": 255,
-                "dimmer": 255,
-                "duration": 100,
-            },
+            "Overhead Effects": {"red": 255, "green": 64, "dimmer": 255, "duration": 100},
         },
     )
     SONG_ONGOING_METAL = (
@@ -358,14 +344,10 @@ class Scenario(Enum):
             "Moving Head": {"dimmer": 255},
             "Overhead Effects": {"white": 255, "dimmer": 255},
             "Karaoke Lights": {"white": 26, "dimmer": 26},
-            "Smoke Machine": {"smoke_gap": 30000, "duration": 5000},
+            "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {
-                "white": 255,
-                "dimmer": 255,
-                "duration": 100,
-            },
+            "Overhead Effects": {"white": 255, "dimmer": 255, "duration": 100},
         },
     )
     SONG_ONGOING_DISCO = (
@@ -401,17 +383,12 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "blue": 96, "dimmer": 255},
-            "Karaoke Lights": {"red": 26, "blue": 10, "dimmer": 26},
-            "Smoke Machine": {"smoke_gap": 10000, "duration": 5000},
+            "Overhead Effects": {"red": 255, "blue": 255, "dimmer": 255},
+            "Karaoke Lights": {"red": 26, "blue": 26, "dimmer": 26},
+            "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {
-                "red": 255,
-                "blue": 96,
-                "dimmer": 255,
-                "duration": 100,
-            },
+            "Overhead Effects": {"red": 255, "blue": 255, "dimmer": 255, "duration": 100},
         },
     )
     SONG_ONGOING_REGGAE = (
@@ -447,12 +424,12 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "dimmer": 255},
-            "Karaoke Lights": {"red": 26, "dimmer": 26},
+            "Overhead Effects": {"red": 255, "green": 255, "dimmer": 255},
+            "Karaoke Lights": {"red": 26, "green": 26, "dimmer": 26},
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100},
+            "Overhead Effects": {"red": 255, "green": 255, "dimmer": 255, "duration": 100},
         },
     )
     SONG_ONGOING_BLUES = (
@@ -488,12 +465,12 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "dimmer": 255},
-            "Karaoke Lights": {"red": 26, "dimmer": 26},
+            "Overhead Effects": {"blue": 255, "dimmer": 255},
+            "Karaoke Lights": {"blue": 26, "dimmer": 26},
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100},
+            "Overhead Effects": {"blue": 255, "dimmer": 255, "duration": 100},
         },
     )
     SONG_ONGOING_CLASSICAL = (
@@ -529,12 +506,12 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "dimmer": 255},
-            "Karaoke Lights": {"red": 26, "dimmer": 26},
+            "Overhead Effects": {"white": 255, "dimmer": 255},
+            "Karaoke Lights": {"white": 26, "dimmer": 26},
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100},
+            "Overhead Effects": {"white": 255, "dimmer": 255, "duration": 100},
         },
     )
     SONG_ONGOING_HIPHOP = (
@@ -570,12 +547,12 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "dimmer": 255},
-            "Karaoke Lights": {"red": 26, "dimmer": 26},
+            "Overhead Effects": {"green": 255, "blue": 255, "dimmer": 255},
+            "Karaoke Lights": {"green": 26, "blue": 26, "dimmer": 26},
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100},
+            "Overhead Effects": {"green": 255, "blue": 255, "dimmer": 255, "duration": 100},
         },
     )
     SONG_ONGOING_COUNTRY = (
@@ -611,12 +588,12 @@ class Scenario(Enum):
         {
             "House Lights": {"dimmer": 0},
             "Moving Head": {"dimmer": 255},
-            "Overhead Effects": {"red": 255, "dimmer": 255},
-            "Karaoke Lights": {"red": 26, "dimmer": 26},
+            "Overhead Effects": {"red": 255, "green": 96, "dimmer": 255},
+            "Karaoke Lights": {"red": 26, "green": 10, "dimmer": 26},
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100},
+            "Overhead Effects": {"red": 255, "green": 96, "dimmer": 255, "duration": 100},
         },
     )
     SONG_ENDING = (


### PR DESCRIPTION
## Summary
- assign genre-specific colors to karaoke and overheads
- restore mood for intermission and song start/ending
- keep smoke settings consistent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68738de96b208329972adf5f10f2ae34