### PR TITLE
Optimize DMX output

### DIFF
--- a/main.py
+++ b/main.py
@@ -281,6 +281,8 @@ class BeatDMXShow:
         self.scenario = scn
         self.smoke_gap_ms, self.smoke_duration_ms = parameters.smoke_settings(scn)
         self.beat_ends.clear()
+        if self.controller:
+            self.controller.reset()
         updates = dict(scn.updates)
         updates.pop("Smoke Machine", None)
         self._print_state_change(updates)

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -10,6 +10,9 @@ class DummyCtrl:
     def update(self):
         pass
 
+    def reset(self):
+        pass
+
 
 def test_intermission_to_start_allowed():
     show = BeatDMXShow(genre_model=None)


### PR DESCRIPTION
## Summary
- add a reset method to `DmxDevice` and `DMX`
- stop sending identical DMX frames
- clear all channels when changing scenarios
- adjust tests for new controller method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687398a11a3c8329be249eae55d0529e