### PR TITLE
Use logarithmic VU dimmer scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ dashboard also shows the current VU level along with minimum and maximum
 readings. Chorus, drum solo and crescendo flags appear alongside the song
 state and detected genre at the top.
 Running the show writes VU and dimmer levels to ``vu_dimmer.log`` for debugging.
+The dimmer uses a logarithmic scale so minor changes in volume do not flicker.
 Genre classifier details are also logged to ``ai.log``. The file begins with a
 status line noting whether the genre classifier loaded successfully. Messages
 appear only once even if both the show and classifier write to the same file.

--- a/tests/test_vu_scaling.py
+++ b/tests/test_vu_scaling.py
@@ -1,0 +1,19 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import parameters
+from main import BeatDMXShow
+
+
+def test_vu_to_level_log_scale():
+    zero = BeatDMXShow._vu_to_level(0.0)
+    full = BeatDMXShow._vu_to_level(parameters.VU_FULL)
+    above = BeatDMXShow._vu_to_level(parameters.VU_FULL * 2)
+    low = BeatDMXShow._vu_to_level(parameters.VU_FULL / 10)
+    mid = BeatDMXShow._vu_to_level(parameters.VU_FULL / 2)
+    assert zero == 0
+    assert full == 255
+    assert above == 255
+    assert 0 < low < mid < full
+


### PR DESCRIPTION
## Summary
- apply logarithmic mapping for VU-based dimmer
- document the logarithmic scale in the README
- add tests covering VU scaling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873a304b16c832992467e97a816d9a6