### PR TITLE
Pulse dimmer only on high VU

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ dashboard also shows the current VU level along with minimum and maximum
 readings. Chorus, drum solo and crescendo flags appear alongside the song
 state and detected genre at the top.
 Running the show writes VU and dimmer levels to ``vu_dimmer.log`` for debugging.
-The dimmer now uses a square root scale with 0.8 smoothing.
-High VU quickly reaches full brightness without flicker.
+The dimmer stays off until the VU crosses a threshold, then pulses toward full
+brightness with 0.8 smoothing.
 Genre classifier details are also logged to ``ai.log``. The file begins with a
 status line noting whether the genre classifier loaded successfully. Messages
 appear only once even if both the show and classifier write to the same file.

--- a/main.py
+++ b/main.py
@@ -524,12 +524,12 @@ class BeatDMXShow:
 
     @staticmethod
     def _vu_to_level(vu: float) -> int:
-        """Map a raw VU value to a dimmer level using a square root scale."""
-        ratio = max(0.0, min(1.0, vu / parameters.VU_FULL))
-        if ratio <= 0.0:
+        """Return a dimmer level that pulses only for high VU."""
+        if vu <= parameters.VU_PULSE_THRESHOLD:
             return 0
-        level = math.sqrt(ratio)
-        return min(255, int(level * 255))
+        top = parameters.VU_FULL - parameters.VU_PULSE_THRESHOLD
+        ratio = max(0.0, min(1.0, (vu - parameters.VU_PULSE_THRESHOLD) / top))
+        return min(255, int(ratio * 255))
 
     def _update_overhead_from_vu(self, _ctrl: DMX) -> None:
         """Set Overhead Effects dimmer based on the latest VU reading."""

--- a/parameters.py
+++ b/parameters.py
@@ -31,6 +31,8 @@ PRINT_INTERVAL = 10
 
 # RMS level that results in full intensity for overhead effects
 VU_FULL = 0.3
+# Ratio of VU_FULL that must be exceeded to trigger dimmer pulses
+VU_PULSE_THRESHOLD = VU_FULL * 0.75
 
 # Exponential smoothing factor for dimmer levels
 VU_SMOOTHING = 0.8

--- a/tests/test_vu_scaling.py
+++ b/tests/test_vu_scaling.py
@@ -8,12 +8,19 @@ from main import BeatDMXShow
 
 def test_vu_to_level_scale():
     zero = BeatDMXShow._vu_to_level(0.0)
+    threshold = BeatDMXShow._vu_to_level(parameters.VU_PULSE_THRESHOLD)
     full = BeatDMXShow._vu_to_level(parameters.VU_FULL)
     above = BeatDMXShow._vu_to_level(parameters.VU_FULL * 2)
     low = BeatDMXShow._vu_to_level(parameters.VU_FULL / 10)
     mid = BeatDMXShow._vu_to_level(parameters.VU_FULL / 2)
+    high = BeatDMXShow._vu_to_level(
+        (parameters.VU_FULL + parameters.VU_PULSE_THRESHOLD) / 2
+    )
     assert zero == 0
+    assert threshold == 0
     assert full == 255
     assert above == 255
-    assert 0 < low < mid < full
+    assert low == 0
+    assert mid == 0
+    assert 0 < high < full
 


### PR DESCRIPTION
## Summary
- dim lights until a high VU threshold is reached
- add `VU_PULSE_THRESHOLD` setting
- test the new VU pulse logic
- document threshold behavior in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873a93f7064832985b64df2a6a9d6ac