### PR TITLE
Adjust dimmer baseline behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ dashboard also shows the current VU level along with minimum and maximum
 readings. Chorus, drum solo and crescendo flags appear alongside the song
 state and detected genre at the top.
 Running the show writes VU and dimmer levels to ``vu_dimmer.log`` for debugging.
-The dimmer stays off until the VU crosses a threshold, then pulses toward full
-brightness with 0.8 smoothing.
+The dimmer idles around 25 until the VU crosses a threshold, then rises toward
+175 with 0.8 smoothing. Snare hits briefly push it to full brightness.
 Genre classifier details are also logged to ``ai.log``. The file begins with a
 status line noting whether the genre classifier loaded successfully. Messages
 appear only once even if both the show and classifier write to the same file.

--- a/main.py
+++ b/main.py
@@ -524,12 +524,15 @@ class BeatDMXShow:
 
     @staticmethod
     def _vu_to_level(vu: float) -> int:
-        """Return a dimmer level that pulses only for high VU."""
+        """Return a dimmer level that rises with VU above a baseline."""
+        base = 25
+        peak = 175
         if vu <= parameters.VU_PULSE_THRESHOLD:
-            return 0
+            return base
         top = parameters.VU_FULL - parameters.VU_PULSE_THRESHOLD
         ratio = max(0.0, min(1.0, (vu - parameters.VU_PULSE_THRESHOLD) / top))
-        return min(255, int(ratio * 255))
+        level = base + ratio * (peak - base)
+        return min(peak, int(level))
 
     def _update_overhead_from_vu(self, _ctrl: DMX) -> None:
         """Set Overhead Effects dimmer based on the latest VU reading."""

--- a/tests/test_vu_scaling.py
+++ b/tests/test_vu_scaling.py
@@ -16,11 +16,11 @@ def test_vu_to_level_scale():
     high = BeatDMXShow._vu_to_level(
         (parameters.VU_FULL + parameters.VU_PULSE_THRESHOLD) / 2
     )
-    assert zero == 0
-    assert threshold == 0
-    assert full == 255
-    assert above == 255
-    assert low == 0
-    assert mid == 0
-    assert 0 < high < full
+    assert zero == 25
+    assert threshold == 25
+    assert full == 175
+    assert above == 175
+    assert low == 25
+    assert mid == 25
+    assert 25 < high < full
 


### PR DESCRIPTION
## Summary
- dimmer baseline now 25 and rises to 175 on high VU
- document new behaviour in README
- update tests for new VU scaling logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873adde323883298c82d6ee9926cb5b