### PR TITLE
Fix Overhead dimmer stuck at 255

### DIFF
--- a/main.py
+++ b/main.py
@@ -621,7 +621,8 @@ class BeatDMXShow:
             )
             # Reset the smoothed dimmer so it returns to the expected level
             self.smoothed_vu_dimmer = self._vu_to_level(vu)
-            self.last_vu_dimmer = int(self.smoothed_vu_dimmer)
+            # Do not update last_vu_dimmer here so the next VU update
+            # triggers a DMX refresh back to the baseline level
 
         for group, end in list(self.beat_ends.items()):
             if now >= end:

--- a/tests/test_vu_scaling.py
+++ b/tests/test_vu_scaling.py
@@ -24,3 +24,37 @@ def test_vu_to_level_scale():
     assert mid == 25
     assert 25 < high < full
 
+
+import numpy as np
+from src.audio.beat_detection import SongState
+
+class DummyDetector:
+    def __init__(self) -> None:
+        self.state = SongState.ONGOING
+        self.snare_hit = True
+        self.is_chorus = False
+        self.is_drum_solo = False
+        self.is_crescendo = False
+        self.kick_hit = False
+
+    def process(self, samples, now):
+        return False, 0, False, parameters.VU_FULL
+
+class DummyCtrl:
+    def update(self):
+        pass
+
+    def reset(self):
+        pass
+
+
+def test_snare_resets_smoothed_dimmer():
+    show = BeatDMXShow(genre_model=None)
+    show.controller = DummyCtrl()
+    show.detector = DummyDetector()
+    show.smoothed_vu_dimmer = 255
+    show.last_vu_dimmer = 255
+    show._process_samples(np.zeros(512))
+    assert show.smoothed_vu_dimmer == BeatDMXShow._vu_to_level(parameters.VU_FULL)
+    # last_vu_dimmer is left unchanged so the next VU update triggers
+    # a DMX refresh back to the expected level


### PR DESCRIPTION
## Summary
- avoid overriding `last_vu_dimmer` when resetting the smoothed dimmer after a snare hit
- update regression test to match new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873b25f15a08329883c0ea5d2f6d090