### PR TITLE
Clamp smoothed dimmer value

### DIFF
--- a/main.py
+++ b/main.py
@@ -543,7 +543,12 @@ class BeatDMXShow:
 
         level = self._vu_to_level(self.current_vu)
         smooth = parameters.VU_SMOOTHING
-        self.smoothed_vu_dimmer = self.smoothed_vu_dimmer * smooth + level * (1 - smooth)
+        self.smoothed_vu_dimmer = (
+            self.smoothed_vu_dimmer * smooth + level * (1 - smooth)
+        )
+        peak = self._vu_to_level(parameters.VU_FULL)
+        if self.smoothed_vu_dimmer > peak:
+            self.smoothed_vu_dimmer = peak
         final_level = int(self.smoothed_vu_dimmer)
         if self.log_file:
             self.log_file.write(


### PR DESCRIPTION
## Summary
- keep smoothed_vu_dimmer within the expected 0-175 range

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873b909daac8329b6fa8ced9d634ff3