### PR TITLE
Fix VU dimmer reset on beat

### DIFF
--- a/main.py
+++ b/main.py
@@ -505,6 +505,10 @@ class BeatDMXShow:
                         print(f"Beat update {group}: {update}", flush=True)
                     self._apply_update(group, update)
                     self.beat_ends[group] = now + dur
+                    if group == "Overhead Effects" and "dimmer" in update:
+                        # Reset smoothing so the dimmer returns to the VU level
+                        self.smoothed_vu_dimmer = self._vu_to_level(self.current_vu)
+                        # Do not update last_vu_dimmer here
 
     def _tick(self, now: float) -> None:
         if (

--- a/tests/test_vu_scaling.py
+++ b/tests/test_vu_scaling.py
@@ -58,3 +58,30 @@ def test_snare_resets_smoothed_dimmer():
     assert show.smoothed_vu_dimmer == BeatDMXShow._vu_to_level(parameters.VU_FULL)
     # last_vu_dimmer is left unchanged so the next VU update triggers
     # a DMX refresh back to the expected level
+
+class BeatDummyDetector:
+    def __init__(self) -> None:
+        self.state = SongState.ONGOING
+        self.snare_hit = False
+        self.is_chorus = False
+        self.is_drum_solo = False
+        self.is_crescendo = False
+        self.kick_hit = False
+
+    def process(self, samples, now):
+        return True, 120, False, parameters.VU_FULL
+
+
+def test_beat_resets_smoothed_dimmer():
+    show = BeatDMXShow(dashboard=False, genre_model=None)
+    show.controller = DummyCtrl()
+    show.smoke = None
+    show.smoke_on = False
+    show.smoke_gap_ms = 0
+    show.smoothed_vu_dimmer = 255
+    show.last_vu_dimmer = 255
+    show.detector = BeatDummyDetector()
+    show.current_vu = parameters.VU_FULL
+    show.scenario.beat = {"Overhead Effects": {"dimmer": 255, "duration": 100}}
+    show._handle_beat(120, 0.0)
+    assert show.smoothed_vu_dimmer == BeatDMXShow._vu_to_level(parameters.VU_FULL)


### PR DESCRIPTION
## Summary
- reset smoothed VU dimmer when beat pulses set Overhead Effects dimmer
- test beat reset logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873bbffc06083299ab1395aee894b07