### PR TITLE
Fix stuck dimmer after beat update

### DIFF
--- a/main.py
+++ b/main.py
@@ -506,9 +506,10 @@ class BeatDMXShow:
                     self._apply_update(group, update)
                     self.beat_ends[group] = now + dur
                     if group == "Overhead Effects" and "dimmer" in update:
+                        # Track the override value so the VU update restores it
+                        self.last_vu_dimmer = update["dimmer"]
                         # Reset smoothing so the dimmer returns to the VU level
                         self.smoothed_vu_dimmer = self._vu_to_level(self.current_vu)
-                        # Do not update last_vu_dimmer here
 
     def _tick(self, now: float) -> None:
         if (


### PR DESCRIPTION
## Summary
- prevent beat pulses from leaving the Overhead Effects dimmer at 255
- track the beat override to allow _update_overhead_from_vu to restore the level

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c730c91c8329868bc9995ee59c12