### PR TITLE
Implement special events and timers

### DIFF
--- a/parameters.py
+++ b/parameters.py
@@ -108,7 +108,7 @@ class Scenario(Enum):
         predecessors: list[str],
         successors: list[str],
         updates: dict[str, dict[str, float]],
-        beat: dict[str, dict[str, float]] | None = None,
+        events: dict[str, dict[str, dict[str, float]]] | None = None,
     ):
         obj = object.__new__(cls)
         obj._value_ = label
@@ -117,7 +117,7 @@ class Scenario(Enum):
         obj.predecessor_names = predecessors
         obj.successor_names = successors
         obj.updates = updates
-        obj.beat = beat
+        obj.events = events or {}
         obj.predecessors = []  
         obj.successors = []    
         return obj
@@ -188,7 +188,9 @@ class Scenario(Enum):
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100},
+            "beat": {
+                "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100}
+            }
         },
     )
     SONG_ONGOING_JAZZ = (
@@ -229,7 +231,9 @@ class Scenario(Enum):
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"red": 255, "blue": 255, "dimmer": 255, "duration": 100},
+            "beat": {
+                "Overhead Effects": {"red": 255, "blue": 255, "dimmer": 255, "duration": 100}
+            }
         },
     )
     SONG_ONGOING_POP = (
@@ -270,7 +274,9 @@ class Scenario(Enum):
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"green": 255, "dimmer": 255, "duration": 100},
+            "beat": {
+                "Overhead Effects": {"green": 255, "dimmer": 255, "duration": 100}
+            }
         },
     )
     SONG_ONGOING_ROCK = (
@@ -311,7 +317,9 @@ class Scenario(Enum):
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"red": 255, "green": 64, "dimmer": 255, "duration": 100},
+            "beat": {
+                "Overhead Effects": {"red": 255, "green": 64, "dimmer": 255, "duration": 100}
+            }
         },
     )
     SONG_ONGOING_METAL = (
@@ -352,7 +360,9 @@ class Scenario(Enum):
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"white": 255, "dimmer": 255, "duration": 100},
+            "beat": {
+                "Overhead Effects": {"white": 255, "dimmer": 255, "duration": 100}
+            }
         },
     )
     SONG_ONGOING_DISCO = (
@@ -393,7 +403,9 @@ class Scenario(Enum):
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"red": 255, "blue": 255, "dimmer": 255, "duration": 100},
+            "beat": {
+                "Overhead Effects": {"red": 255, "blue": 255, "dimmer": 255, "duration": 100}
+            }
         },
     )
     SONG_ONGOING_REGGAE = (
@@ -434,7 +446,9 @@ class Scenario(Enum):
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"red": 255, "green": 255, "dimmer": 255, "duration": 100},
+            "beat": {
+                "Overhead Effects": {"red": 255, "green": 255, "dimmer": 255, "duration": 100}
+            }
         },
     )
     SONG_ONGOING_BLUES = (
@@ -475,7 +489,9 @@ class Scenario(Enum):
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"blue": 255, "dimmer": 255, "duration": 100},
+            "beat": {
+                "Overhead Effects": {"blue": 255, "dimmer": 255, "duration": 100}
+            }
         },
     )
     SONG_ONGOING_CLASSICAL = (
@@ -516,7 +532,9 @@ class Scenario(Enum):
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"white": 255, "dimmer": 255, "duration": 100},
+            "beat": {
+                "Overhead Effects": {"white": 255, "dimmer": 255, "duration": 100}
+            }
         },
     )
     SONG_ONGOING_HIPHOP = (
@@ -557,7 +575,9 @@ class Scenario(Enum):
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"green": 255, "blue": 255, "dimmer": 255, "duration": 100},
+            "beat": {
+                "Overhead Effects": {"green": 255, "blue": 255, "dimmer": 255, "duration": 100}
+            }
         },
     )
     SONG_ONGOING_COUNTRY = (
@@ -598,7 +618,9 @@ class Scenario(Enum):
             "Smoke Machine": {"smoke_gap": 15000, "duration": 5000},
         },
         {
-            "Overhead Effects": {"red": 255, "green": 96, "dimmer": 255, "duration": 100},
+            "beat": {
+                "Overhead Effects": {"red": 255, "green": 96, "dimmer": 255, "duration": 100}
+            }
         },
     )
     SONG_ENDING = (

--- a/tests/test_vu_scaling.py
+++ b/tests/test_vu_scaling.py
@@ -54,6 +54,9 @@ def test_snare_resets_smoothed_dimmer():
     show.detector = DummyDetector()
     show.smoothed_vu_dimmer = 255
     show.last_vu_dimmer = 255
+    show.scenario.events = {
+        "snare_hit": {"Overhead Effects": {"dimmer": 255, "duration": 100}}
+    }
     show._process_samples(np.zeros(512))
     assert show.smoothed_vu_dimmer == BeatDMXShow._vu_to_level(parameters.VU_FULL)
     # last_vu_dimmer is left unchanged so the next VU update triggers
@@ -82,6 +85,8 @@ def test_beat_resets_smoothed_dimmer():
     show.last_vu_dimmer = 255
     show.detector = BeatDummyDetector()
     show.current_vu = parameters.VU_FULL
-    show.scenario.beat = {"Overhead Effects": {"dimmer": 255, "duration": 100}}
+    show.scenario.events = {
+        "beat": {"Overhead Effects": {"dimmer": 255, "duration": 100}}
+    }
     show._handle_beat(120, 0.0)
     assert show.smoothed_vu_dimmer == BeatDMXShow._vu_to_level(parameters.VU_FULL)


### PR DESCRIPTION
## Summary
- extend `Scenario` definitions with `events` for beat, chorus, snare hits, and timers
- handle special events in `BeatDMXShow`
- trigger timer-based fades when entering ongoing scenarios
- adjust tests for new scenario structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873cc9977b48329b097fdb99c7f8d48