### PR TITLE
Fix genre reset when song changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -491,6 +491,11 @@ class BeatDMXShow:
             logger.debug("Ignore Ongoing transition until genre classified")
             return
 
+        if state in {SongState.STARTING, SongState.INTERMISSION, SongState.ENDING}:
+            self.last_genre = None
+            self.genre_label = ""
+            self.classifying = False
+
         self._flush_beat_line()
         if self.dashboard_enabled:
             self.dashboard.set_state(state.value)
@@ -515,9 +520,6 @@ class BeatDMXShow:
         self._set_scenario(mapping.get(state, Scenario.INTERMISSION))
         if state == SongState.STARTING:
             self.song_id += 1
-            self.last_genre = None
-            self.genre_label = ""
-            self.classifying = False
             self.buffering = True
             self.buffer_start_time = time.time()
             self.classify_after = time.time() + 5.0

--- a/tests/test_genre_reset.py
+++ b/tests/test_genre_reset.py
@@ -1,0 +1,38 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from parameters import Scenario
+from main import BeatDMXShow
+from src.audio.beat_detection import SongState
+
+class DummyDashboard:
+    def __init__(self):
+        self.genre = None
+        self.state = None
+        self.groups = {}
+    def set_genre(self, name):
+        self.genre = name
+    def set_state(self, state):
+        self.state = state
+    def set_group(self, name, vals):
+        self.groups[name] = vals
+
+
+class DummyCtrl:
+    def update(self):
+        pass
+
+    def reset(self):
+        pass
+
+
+def test_genre_cleared_on_state_change():
+    show = BeatDMXShow(dashboard=False, genre_model=None)
+    show.dashboard_enabled = True
+    show.dashboard = DummyDashboard()
+    show.controller = DummyCtrl()
+    show.last_genre = Scenario.SONG_ONGOING_ROCK
+    show._handle_state_change(SongState.STARTING)
+    assert show.last_genre is None
+    assert show.dashboard.genre == ""


### PR DESCRIPTION
## Summary
- reset genre info before printing dashboard updates
- test that the dashboard shows an empty genre when a new song starts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873d2bc9948832999f8a07c2f106d45