### PR TITLE
Remove BPM dimmer pulses

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,14 +194,14 @@ Stage lights fade to black as overheads rise to 30% warm white. Moving head cent
 
 ### Song Ongoing - Slow (BPM <80)
 
-* Overhead **deep indigo** pulse every 2 beats (RGB: 54, 0, 88).
+* Overhead **deep indigo** flashes every 2 beats (RGB: 54, 0, 88).
 * Accent color: **soft lavender** highlights crescendos (RGB: 200, 160, 255).
 * Moving head gentle pan focusing on the artist.
 * **2-second smoke burst** every **15 seconds**.
 
 ### Song Ongoing - Jazz (80-110 BPM)
 
-* Overhead **amber** pulse each beat (RGB: 255, 147, 41).
+* Overhead **amber** accent on each beat (RGB: 255, 147, 41).
 * Accent color: **teal** accents highlight dynamic sections (RGB: 0, 128, 128).
 * Moving head performs narrow, rhythmic sweeps.
 * **3-second smoke burst** every **30 seconds**.
@@ -210,13 +210,13 @@ Stage lights fade to black as overheads rise to 30% warm white. Moving head cent
 
 * Overhead **candy pink** chase each beat (RGB: 255, 64, 200).
 * Accent color: **bright cyan** flashes on strong beats (RGB: 0, 200, 255).
-* Beat accents push Overhead Effects to full intensity for 100 ms beyond the VU level.
+* Beat accents change color for 100 ms beyond the VU level.
 * Moving head executes wide, energetic sweeps.
 * **3-second smoke burst** every **30 seconds**.
 
 ### Song Ongoing - Rock (130-160 BPM)
 
-* Overhead **fire red** pulse each beat using strong low-frequency peaks (RGB: 255, 0, 0).
+* Overhead **fire red** accent each beat using strong low-frequency peaks (RGB: 255, 0, 0).
 * Accent color: **electric blue** in sustained sections (RGB: 0, 64, 255).
 * Chorus downbeats switch to **golden amber** (RGB: 255, 180, 0).
 * Moving head rapid pan and tilt movements.
@@ -224,7 +224,7 @@ Stage lights fade to black as overheads rise to 30% warm white. Moving head cent
 
 ### Song Ongoing - Metal (>160 BPM)
 
-* Overhead **icy white** pulse each beat (RGB: 255, 255, 255).
+* Overhead **icy white** accent each beat (RGB: 255, 255, 255).
 * Accent color: **UV purple** washes during intense passages (RGB: 128, 0, 255).
 * **Blood red** bursts on strong low-frequency hits (RGB: 180, 0, 0).
 * Moving head performs rapid, erratic sweeps.

--- a/main.py
+++ b/main.py
@@ -167,7 +167,6 @@ class BeatDMXShow:
         self.smoke_start = 0.0
         self.last_smoke_time = 0.0
         self.scenario = parameters.SCENARIO_MAP[Scenario.INTERMISSION]
-        self.last_bpm = 0.0
         self.smoke_gap_ms, self.smoke_duration_ms = parameters.smoke_settings(self.scenario)
         self.groups: Dict[str, list] = {}
         self.beat_ends: Dict[str, float] = {}
@@ -541,7 +540,6 @@ class BeatDMXShow:
 
     def _handle_beat(self, bpm: float, now: float) -> None:
         if bpm:
-            self.last_bpm = bpm
             label = self._genre_label(self.last_genre)
             line = f"Beat at {bpm:.2f} BPM" + (f" - genre {label}" if label else "")
             if self.dashboard_enabled:

--- a/parameters.py
+++ b/parameters.py
@@ -189,7 +189,7 @@ class Scenario(Enum):
         },
         {
             "beat": {
-                "Overhead Effects": {"red": 255, "dimmer": 255, "duration": 100}
+                "Overhead Effects": {"red": 255, "duration": 100}
             },
             "chorus": {
                 "Overhead Effects": {"blue": 255, "dimmer": 255},
@@ -247,7 +247,7 @@ class Scenario(Enum):
         },
         {
             "beat": {
-                "Overhead Effects": {"red": 255, "blue": 255, "dimmer": 255, "duration": 100}
+                "Overhead Effects": {"red": 255, "blue": 255, "duration": 100}
             },
             "chorus": {
                 "Overhead Effects": {"green": 255, "dimmer": 255},
@@ -305,7 +305,7 @@ class Scenario(Enum):
         },
         {
             "beat": {
-                "Overhead Effects": {"green": 255, "dimmer": 255, "duration": 100}
+                "Overhead Effects": {"green": 255, "duration": 100}
             },
             "chorus": {
                 "Overhead Effects": {"green": 255, "blue": 128, "dimmer": 255},
@@ -363,7 +363,7 @@ class Scenario(Enum):
         },
         {
             "beat": {
-                "Overhead Effects": {"red": 255, "green": 64, "dimmer": 255, "duration": 100}
+                "Overhead Effects": {"red": 255, "green": 64, "duration": 100}
             },
             "chorus": {
                 "Overhead Effects": {"red": 255, "blue": 64, "dimmer": 255},
@@ -421,7 +421,7 @@ class Scenario(Enum):
         },
         {
             "beat": {
-                "Overhead Effects": {"white": 255, "dimmer": 255, "duration": 100}
+                "Overhead Effects": {"white": 255, "duration": 100}
             },
             "chorus": {
                 "Overhead Effects": {"white": 255, "dimmer": 255},
@@ -479,7 +479,7 @@ class Scenario(Enum):
         },
         {
             "beat": {
-                "Overhead Effects": {"red": 255, "blue": 255, "dimmer": 255, "duration": 100}
+                "Overhead Effects": {"red": 255, "blue": 255, "duration": 100}
             },
             "chorus": {
                 "Overhead Effects": {"green": 255, "blue": 255, "dimmer": 255},
@@ -537,7 +537,7 @@ class Scenario(Enum):
         },
         {
             "beat": {
-                "Overhead Effects": {"red": 255, "green": 255, "dimmer": 255, "duration": 100}
+                "Overhead Effects": {"red": 255, "green": 255, "duration": 100}
             },
             "chorus": {
                 "Overhead Effects": {"red": 255, "green": 128, "dimmer": 255},
@@ -595,7 +595,7 @@ class Scenario(Enum):
         },
         {
             "beat": {
-                "Overhead Effects": {"blue": 255, "dimmer": 255, "duration": 100}
+                "Overhead Effects": {"blue": 255, "duration": 100}
             },
             "chorus": {
                 "Overhead Effects": {"green": 255, "blue": 128, "dimmer": 255},
@@ -653,7 +653,7 @@ class Scenario(Enum):
         },
         {
             "beat": {
-                "Overhead Effects": {"white": 255, "dimmer": 255, "duration": 100}
+                "Overhead Effects": {"white": 255, "duration": 100}
             },
             "chorus": {
                 "Overhead Effects": {"warm_white": 255, "dimmer": 255},
@@ -711,7 +711,7 @@ class Scenario(Enum):
         },
         {
             "beat": {
-                "Overhead Effects": {"green": 255, "blue": 255, "dimmer": 255, "duration": 100}
+                "Overhead Effects": {"green": 255, "blue": 255, "duration": 100}
             },
             "chorus": {
                 "Overhead Effects": {"red": 255, "blue": 255, "dimmer": 255},
@@ -769,7 +769,7 @@ class Scenario(Enum):
         },
         {
             "beat": {
-                "Overhead Effects": {"red": 255, "green": 96, "dimmer": 255, "duration": 100}
+                "Overhead Effects": {"red": 255, "green": 96, "duration": 100}
             },
             "chorus": {
                 "Overhead Effects": {"red": 255, "green": 96, "dimmer": 255},

--- a/tests/test_vu_scaling.py
+++ b/tests/test_vu_scaling.py
@@ -86,7 +86,7 @@ def test_beat_resets_smoothed_dimmer():
     show.detector = BeatDummyDetector()
     show.current_vu = parameters.VU_FULL
     show.scenario.events = {
-        "beat": {"Overhead Effects": {"dimmer": 255, "duration": 100}}
+        "beat": {"Overhead Effects": {"duration": 100}}
     }
     show._handle_beat(120, 0.0)
-    assert show.smoothed_vu_dimmer == BeatDMXShow._vu_to_level(parameters.VU_FULL)
+    assert show.smoothed_vu_dimmer == 255


### PR DESCRIPTION
## Summary
- remove BPM-based dimmer from scenarios
- drop unused `last_bpm` tracking
- keep dimmer unaffected on beat events
- update show cue descriptions for new behaviour
- adjust tests for beat dimmer change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873d871dd4083298298b5e609dee9d8