### PR TITLE
Increase detection sensitivity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,6 @@
     faces the audience
 - Avoid cues that rely on detecting solos or other musical details the
    software cannot sense
-  - Chorus and crescendo detection uses a 0.5-second debounce to avoid
+  - Chorus and crescendo detection uses a 0.375-second debounce to avoid
     flicker
   - `DMX_FPS` sets how many DMX frames are transmitted per second

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ BPM every few seconds and runs a genre classifier based on the
 `music_genres_classification` transformer model stored under
 `models/music_genres_classification`. The detector also provides lightweight
 heuristics for chorus, crescendo and drum solo detection using a
-0.5-second debounce.
+0.375-second debounce.
 
 ### Usage
 
@@ -108,7 +108,7 @@ and chorus sections. These rely on RMS loudness trends, harmonic/percussive
 ratios and spectral flatness. Results are heuristic and may produce occasional
 false triggers but can be useful for debugging lighting ideas. Their status is
 visible in dashboard mode. Chorus and crescendo detection now include a
-0.5-second debounce interval to reduce erratic short bursts.
+0.375-second debounce interval to reduce erratic short bursts.
 You can tweak this debounce time by editing the ``BeatDetector``
 ``chorus_debounce`` and ``crescendo_debounce`` parameters.
 

--- a/src/audio/beat_detection.py
+++ b/src/audio/beat_detection.py
@@ -60,8 +60,8 @@ class BeatDetector:
         start_duration: float = 2.0,
         end_duration: float = 3.0,
         print_interval: float = 10.0,
-        chorus_debounce: float = 0.5,
-        crescendo_debounce: float = 0.5,
+        chorus_debounce: float = 0.375,
+        crescendo_debounce: float = 0.375,
     ) -> None:
         self.samplerate = samplerate
         self.tempo = aubio.tempo("default", 1024, 512, samplerate)
@@ -145,8 +145,8 @@ class BeatDetector:
         flatness = float(
             librosa.feature.spectral_flatness(y=samples, n_fft=n_fft).mean()
         )
-        chorus_raw = rms > 0.1 and flatness < 0.2
-        crescendo_raw = rms > self.previous_rms * 1.1
+        chorus_raw = rms > 0.075 and flatness < 0.25
+        crescendo_raw = rms > self.previous_rms * 1.075
         self.is_chorus = self.chorus_flag.update(chorus_raw, now)
         self.is_crescendo = self.crescendo_flag.update(crescendo_raw, now)
         self.previous_rms = rms
@@ -155,7 +155,7 @@ class BeatDetector:
         y_harm, y_perc = librosa.decompose.hpss(S)
         perc_energy = float(np.sum(np.abs(y_perc) ** 2))
         harm_energy = float(np.sum(np.abs(y_harm) ** 2))
-        self.is_drum_solo = perc_energy > 3 * harm_energy
+        self.is_drum_solo = perc_energy > 2.25 * harm_energy
 
         # Transient detection for snare/kick hits
         self.snare_hit = False
@@ -166,9 +166,9 @@ class BeatDetector:
                     y=samples, sr=self.samplerate, n_fft=n_fft
                 ).mean()
             )
-            if centroid > 4000:
+            if centroid > 3000:
                 self.snare_hit = True
-            elif centroid < 500:
+            elif centroid < 625:
                 self.kick_hit = True
 
         # song state machine


### PR DESCRIPTION
## Summary
- document 0.375s debounce for chorus and crescendo detections
- tune beat detection thresholds for more sensitivity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f683e13508329a8c5963b66084289