### PR TITLE
Clarify moving head color defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ Note: the Overhead Effects group expects LumiPar 12UQPro fixtures with a white
 channel. When testing with a LumiPar 7UTRI the controller now maps ``white`` to
 equal RGB values so scenarios need no manual changes.
 
+The moving head's shutter automatically opens when the dimmer is above zero.
+If no color is provided, all four color channels (red, green, blue and white)
+default to full so the beam always appears during songs.
+
 ## Show
 
 Lighting cues follow the AI-detected genre. LumiPar 12UAW5 units double as house lights.

--- a/parameters.py
+++ b/parameters.py
@@ -830,14 +830,12 @@ def _fill_updates() -> None:
                 update.setdefault(ch, 0)
             if update.get("dimmer", 0) > 0:
                 if "shutter" in channels:
-                    update.setdefault("shutter", 255)
-                if "white" in channels:
-                    update.setdefault("white", 255)
-                elif {"red", "green", "blue"}.issubset(channels):
-                    if not any(update.get(c, 0) > 0 for c in ("red", "green", "blue")):
-                        update.setdefault("red", 255)
-                        update.setdefault("green", 255)
-                        update.setdefault("blue", 255)
+                    update.setdefault("shutter", 63)
+                color_names = [c for c in ("red", "green", "blue", "white") if c in channels]
+                if color_names:
+                    if not any(update.get(c, 0) > 0 for c in color_names):
+                        for c in color_names:
+                            update.setdefault(c, 255)
 
 
 _fill_updates()


### PR DESCRIPTION
## Summary
- document how the moving head automatically opens its shutter and uses white when no colour is provided
- default all moving head colour channels to full when dimmer is set

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688be5bb35988329b190df9225429c17