### PR TITLE
test: add fixture tests

### DIFF
--- a/tests/test_fuzzix_partyparuv_7ch.py
+++ b/tests/test_fuzzix_partyparuv_7ch.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from dmx.Fuzzix_PartyParUV_7ch import Fuzzix_PartyParUV_7ch
+
+
+def test_fuzzix_partyparuv_7ch_controls():
+    print("Running Fuzzix PartyPar UV 7ch test")
+    lamp = Fuzzix_PartyParUV_7ch(1)
+    print("Setting dimmer")
+    lamp.set_dimmer(100)
+    time.sleep(3)
+    print("Setting uv1")
+    lamp.set_channel("uv1", 10)
+    time.sleep(3)
+    print("Setting uv2")
+    lamp.set_channel("uv2", 20)
+    time.sleep(3)
+    print("Setting uv3")
+    lamp.set_channel("uv3", 30)
+    time.sleep(3)
+    print("Setting uv4")
+    lamp.set_channel("uv4", 40)
+    time.sleep(3)
+    print("Setting strobe")
+    lamp.set_strobe(200)
+    time.sleep(3)
+    print("Setting macro")
+    lamp.set_channel("macro", 150)
+    time.sleep(3)
+    frame = lamp.frame()
+    assert frame[lamp.channels["dimmer"]] == 100
+    assert frame[lamp.channels["uv1"]] == 10
+    assert frame[lamp.channels["uv2"]] == 20
+    assert frame[lamp.channels["uv3"]] == 30
+    assert frame[lamp.channels["uv4"]] == 40
+    assert frame[lamp.channels["strobe"]] == 200
+    assert frame[lamp.channels["macro"]] == 150

--- a/tests/test_prolights_lumipar12uaw5_7ch.py
+++ b/tests/test_prolights_lumipar12uaw5_7ch.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from dmx.Prolights_LumiPar12UAW5_7ch import Prolights_LumiPar12UAW5_7ch
+
+
+def test_lumipar12uaw5_7ch_controls():
+    print("Running Prolights LumiPar 12 UAW5 7ch test")
+    lamp = Prolights_LumiPar12UAW5_7ch(1)
+    print("Setting amber")
+    lamp.set_channel("amber", 50)
+    time.sleep(3)
+    print("Setting cold white")
+    lamp.set_channel("cold_white", 60)
+    time.sleep(3)
+    print("Setting warm white")
+    lamp.set_channel("warm_white", 70)
+    time.sleep(3)
+    print("Setting strobe")
+    lamp.set_strobe(80)
+    time.sleep(3)
+    print("Setting dimmer")
+    lamp.set_dimmer(90)
+    time.sleep(3)
+    print("Setting programs")
+    lamp.set_channel("programs", 100)
+    time.sleep(3)
+    print("Setting dimmer curve")
+    lamp.set_channel("dimmer_curve", 110)
+    time.sleep(3)
+    frame = lamp.frame()
+    assert frame[lamp.channels["amber"]] == 50
+    assert frame[lamp.channels["cold_white"]] == 60
+    assert frame[lamp.channels["warm_white"]] == 70
+    assert frame[lamp.channels["strobe"]] == 80
+    assert frame[lamp.channels["dimmer"]] == 90
+    assert frame[lamp.channels["programs"]] == 100
+    assert frame[lamp.channels["dimmer_curve"]] == 110

--- a/tests/test_prolights_lumipar12uqpro_4ch.py
+++ b/tests/test_prolights_lumipar12uqpro_4ch.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from dmx.Prolights_LumiPar12UQPro_4ch import Prolights_LumiPar12UQPro_4ch
+
+
+def test_lumipar12uqpro_4ch_color():
+    print("Running Prolights LumiPar 12 UQ Pro 4ch test")
+    lamp = Prolights_LumiPar12UQPro_4ch(1)
+    print("Setting green")
+    lamp.set_channel("green", 20)
+    time.sleep(3)
+    print("Setting red")
+    lamp.set_channel("red", 10)
+    time.sleep(3)
+    print("Setting blue")
+    lamp.set_channel("blue", 30)
+    time.sleep(3)
+    print("Setting white")
+    lamp.set_channel("white", 40)
+    time.sleep(3)
+    frame = lamp.frame()
+    assert frame[lamp.channels["red"]] == 10
+    assert frame[lamp.channels["green"]] == 20
+    assert frame[lamp.channels["blue"]] == 30
+    assert frame[lamp.channels["white"]] == 40

--- a/tests/test_prolights_lumipar12uqpro_9ch.py
+++ b/tests/test_prolights_lumipar12uqpro_9ch.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from dmx.Prolights_LumiPar12UQPro_9ch import Prolights_LumiPar12UQPro_9ch
+
+
+def test_lumipar12uqpro_9ch_controls():
+    print("Running Prolights LumiPar 12 UQ Pro 9ch test")
+    lamp = Prolights_LumiPar12UQPro_9ch(1)
+    print("Setting green")
+    lamp.set_channel("green", 2)
+    time.sleep(3)
+    print("Setting red")
+    lamp.set_channel("red", 1)
+    time.sleep(3)
+    print("Setting blue")
+    lamp.set_channel("blue", 3)
+    time.sleep(3)
+    print("Setting white")
+    lamp.set_channel("white", 4)
+    time.sleep(3)
+    print("Setting strobe")
+    lamp.set_strobe(5)
+    time.sleep(3)
+    print("Setting dimmer")
+    lamp.set_dimmer(6)
+    time.sleep(3)
+    print("Setting color macros")
+    lamp.set_channel("color_macros", 7)
+    time.sleep(3)
+    print("Setting programs")
+    lamp.set_channel("programs", 8)
+    time.sleep(3)
+    print("Setting dimmer curve")
+    lamp.set_channel("dimmer_curve", 9)
+    time.sleep(3)
+    frame = lamp.frame()
+    assert frame[lamp.channels["red"]] == 1
+    assert frame[lamp.channels["green"]] == 2
+    assert frame[lamp.channels["blue"]] == 3
+    assert frame[lamp.channels["white"]] == 4
+    assert frame[lamp.channels["strobe"]] == 5
+    assert frame[lamp.channels["dimmer"]] == 6
+    assert frame[lamp.channels["color_macros"]] == 7
+    assert frame[lamp.channels["programs"]] == 8
+    assert frame[lamp.channels["dimmer_curve"]] == 9

--- a/tests/test_prolights_lumipar7utri_3ch.py
+++ b/tests/test_prolights_lumipar7utri_3ch.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from dmx.Prolights_LumiPar7UTRI_3ch import Prolights_LumiPar7UTRI_3ch
+
+
+def test_lumipar7utri_3ch_color():
+    print("Running Prolights LumiPar 7 UTRI 3ch test")
+    lamp = Prolights_LumiPar7UTRI_3ch(1)
+    print("Setting green")
+    lamp.set_channel("green", 20)
+    time.sleep(3)
+    print("Setting red")
+    lamp.set_channel("red", 10)
+    time.sleep(3)
+    print("Setting blue")
+    lamp.set_channel("blue", 30)
+    time.sleep(3)
+    frame = lamp.frame()
+    assert frame[lamp.channels["red"]] == 10
+    assert frame[lamp.channels["green"]] == 20
+    assert frame[lamp.channels["blue"]] == 30

--- a/tests/test_prolights_lumipar7utri_8ch.py
+++ b/tests/test_prolights_lumipar7utri_8ch.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from dmx.Prolights_LumiPar7UTRI_8ch import Prolights_LumiPar7UTRI_8ch
+
+
+def test_lumipar7utri_8ch_controls():
+    print("Running Prolights LumiPar 7 UTRI 8ch test")
+    lamp = Prolights_LumiPar7UTRI_8ch(1)
+    print("Setting green")
+    lamp.set_channel("green", 2)
+    time.sleep(3)
+    print("Setting red")
+    lamp.set_channel("red", 1)
+    time.sleep(3)
+    print("Setting blue")
+    lamp.set_channel("blue", 3)
+    time.sleep(3)
+    print("Setting strobe")
+    lamp.set_strobe(4)
+    time.sleep(3)
+    print("Setting dimmer")
+    lamp.set_dimmer(5)
+    time.sleep(3)
+    print("Setting color macros")
+    lamp.set_channel("color_macros", 6)
+    time.sleep(3)
+    print("Setting programs")
+    lamp.set_channel("programs", 7)
+    time.sleep(3)
+    print("Setting dimmer speed")
+    lamp.set_channel("dimmer_speed", 8)
+    time.sleep(3)
+    frame = lamp.frame()
+    assert frame[lamp.channels["red"]] == 1
+    assert frame[lamp.channels["green"]] == 2
+    assert frame[lamp.channels["blue"]] == 3
+    assert frame[lamp.channels["strobe"]] == 4
+    assert frame[lamp.channels["dimmer"]] == 5
+    assert frame[lamp.channels["color_macros"]] == 6
+    assert frame[lamp.channels["programs"]] == 7
+    assert frame[lamp.channels["dimmer_speed"]] == 8

--- a/tests/test_prolights_pixiewash_13ch.py
+++ b/tests/test_prolights_pixiewash_13ch.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from dmx.Prolights_PixieWash_13ch import Prolights_PixieWash_13ch
+
+
+def test_pixiewash_13ch_controls():
+    print("Running Prolights PixieWash 13ch test")
+    lamp = Prolights_PixieWash_13ch(1)
+    print("Setting pan/tilt")
+    lamp.set_pan_tilt(0x1234, 0x5678)
+    time.sleep(3)
+    print("Setting dimmer")
+    lamp.set_dimmer(70)
+    time.sleep(3)
+    print("Setting strobe")
+    lamp.set_strobe(80)
+    time.sleep(3)
+    print("Setting red")
+    lamp.set_channel("red", 10)
+    time.sleep(3)
+    print("Setting green")
+    lamp.set_channel("green", 20)
+    time.sleep(3)
+    print("Setting blue")
+    lamp.set_channel("blue", 30)
+    time.sleep(3)
+    print("Setting white")
+    lamp.set_channel("white", 40)
+    time.sleep(3)
+    print("Setting special")
+    lamp.set_channel("special", 50)
+    time.sleep(3)
+    print("Setting pan/tilt speed")
+    lamp.set_channel("pan_tilt_speed", 60)
+    time.sleep(3)
+    print("Setting color macros")
+    lamp.set_channel("color_macros", 90)
+    time.sleep(3)
+    frame = lamp.frame()
+    assert frame[lamp.channels["pan"]] == 0x12
+    assert frame[lamp.channels["pan_fine"]] == 0x34
+    assert frame[lamp.channels["tilt"]] == 0x56
+    assert frame[lamp.channels["tilt_fine"]] == 0x78
+    assert frame[lamp.channels["dimmer"]] == 70
+    assert frame[lamp.channels["shutter"]] == 80
+    assert frame[lamp.channels["red"]] == 10
+    assert frame[lamp.channels["green"]] == 20
+    assert frame[lamp.channels["blue"]] == 30
+    assert frame[lamp.channels["white"]] == 40
+    assert frame[lamp.channels["special"]] == 50
+    assert frame[lamp.channels["pan_tilt_speed"]] == 60
+    assert frame[lamp.channels["color_macros"]] == 90

--- a/tests/test_whatsoftware_generic_4ch.py
+++ b/tests/test_whatsoftware_generic_4ch.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from dmx.WhatSoftware_Generic_4ch import WhatSoftware_Generic_4ch
+
+
+def test_whatsoftware_generic_4ch_fog():
+    print("Running WhatSoftware Generic 4ch test")
+    lamp = WhatSoftware_Generic_4ch(1)
+    print("Setting fog")
+    lamp.set_channel("fog", 200)
+    time.sleep(3)
+    frame = lamp.frame()
+    assert frame[lamp.channels["fog"]] == 200


### PR DESCRIPTION
## Summary
- print each channel action before setting a value and pause three seconds to observe
- support independent evaluation for fixtures such as the Prolights LumiPar and Fuzzix PartyPar units

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988c86b5f083298196ec7618696597